### PR TITLE
Bugfix: Removed servo legacy

### DIFF
--- a/firmware/Components.cpp
+++ b/firmware/Components.cpp
@@ -139,13 +139,11 @@ ServoSensor::ServoSensor(int channel)
   : Sensor(channel), position_(0.0)
 {
   servo_.attach(board::SENSOR[channel].GPIO[board::TX_NEG]);
-  servo_legacy_.attach(board::SENSOR[channel].GPIO[board::RX_POS]);
 }
 
 ServoSensor::~ServoSensor()
 {
   servo_.detach(); 
-  servo_legacy_.detach();
 }
 
 void ServoSensor::position(float position)
@@ -160,7 +158,6 @@ void ServoSensor::position(float position)
 
   float command = (position_ * 600) + 1500;
   servo_.writeMicroseconds(command);
-  servo_legacy_.writeMicroseconds(command);
 }
 
 float ServoSensor::position()

--- a/firmware/Components.h
+++ b/firmware/Components.h
@@ -69,7 +69,6 @@ namespace platypus
     
   private:
     Servo servo_;
-    Servo servo_legacy_; // TODO: remove this once we only have v3+ boards
     float position_;
   };
 


### PR DESCRIPTION
This PR removes the `servo_legacy_` member variable that was used for backwards compatibility with a hardware bug on pre-4.0 boards.  Since we are now only using 4.0+ boards, this is completely deprecated now.