### PR TITLE
Feature/4 2 0/serial adk integration

### DIFF
--- a/firmware/Components.cpp
+++ b/firmware/Components.cpp
@@ -151,16 +151,18 @@ IMU::IMU(int id, int interval)
   calib.mag_radius = 894;
 
   bno_.setSensorOffsets(calib);
-
+  
 
   // Wait until calibration values are within limits
-  while (!bno_.isFullyCalibrated())
+  //while (!bno_.isFullyCalibrated())
+  while (sysCalib_ < 3)
   {
     delay(100);
     Serial.println(F("Warning: Waiting for IMU to calibrate, please move Boat around"));
     Serial.println(sysCalib_);
     Serial.println(magCalib_);
     Serial.println(accelCalib_);
+    Serial.println(gyroCalib_);
     bno_.getCalibration(&sysCalib_, &gyroCalib_, &accelCalib_, &magCalib_);
   }
 

--- a/firmware/Components.cpp
+++ b/firmware/Components.cpp
@@ -4,6 +4,30 @@ using namespace platypus;
 
 #define WAIT_FOR_CONDITION(condition, timeout_ms) for (unsigned int j = 0; j < (timeout_ms) && !(condition); ++j) delay(1);
 
+void displaySensorOffsets(const adafruit_bno055_offsets_t &calibData)
+{
+    Serial.print("Accelerometer: ");
+    Serial.print(calibData.accel_offset_x); Serial.print(" ");
+    Serial.print(calibData.accel_offset_y); Serial.print(" ");
+    Serial.print(calibData.accel_offset_z); Serial.print(" ");
+
+    Serial.print("\nGyro: ");
+    Serial.print(calibData.gyro_offset_x); Serial.print(" ");
+    Serial.print(calibData.gyro_offset_y); Serial.print(" ");
+    Serial.print(calibData.gyro_offset_z); Serial.print(" ");
+
+    Serial.print("\nMag: ");
+    Serial.print(calibData.mag_offset_x); Serial.print(" ");
+    Serial.print(calibData.mag_offset_y); Serial.print(" ");
+    Serial.print(calibData.mag_offset_z); Serial.print(" ");
+
+    Serial.print("\nAccel Radius: ");
+    Serial.print(calibData.accel_radius);
+
+    Serial.print("\nMag Radius: ");
+    Serial.print(calibData.mag_radius);
+}
+
 void VaporPro::arm()
 {
   disable();
@@ -135,44 +159,53 @@ IMU::IMU(int id, int interval)
 
   bno_.getCalibration(&sysCalib_, &gyroCalib_, &accelCalib_, &magCalib_);
 
+  /*
+  Accelerometer: 65525 65511 32 
+  Gyro: 65534 65534 0 
+  Mag: 65449 65443 261 
+  Accel Radius: 1000
+  Mag Radius: 709
+  */
 
   /* Want to move this to EEPROM and put int option to recalibrate */
   adafruit_bno055_offsets_t calib;
-  calib.accel_offset_x = 0;
-  calib.accel_offset_y = 35;
-  calib.accel_offset_z = 24;
-  calib.gyro_offset_x = 65533;
-  calib.gyro_offset_y = 0;
-  calib.gyro_offset_z = 65535;
-  calib.mag_offset_x = 140;
-  calib.mag_offset_y = 65208;
-  calib.mag_offset_z = 173;
+  calib.accel_offset_x = 65527;
+  calib.accel_offset_y = 65450;
+  calib.accel_offset_z = 65498;
+  calib.gyro_offset_x = 65534;
+  calib.gyro_offset_y = 65535;
+  calib.gyro_offset_z = 0;
+  calib.mag_offset_x = 65487;
+  calib.mag_offset_y = 65380;
+  calib.mag_offset_z = 324;
   calib.accel_radius = 1000;
-  calib.mag_radius = 894;
+  calib.mag_radius = 769;
 
   bno_.setSensorOffsets(calib);
+  
   
 
   // Wait until calibration values are within limits
   //while (!bno_.isFullyCalibrated())
-  while (sysCalib_ < 3)
+  while (sysCalib_ < 3 || magCalib_ < 3)
   {
     delay(100);
-    Serial.println(F("Warning: Waiting for IMU to calibrate, please move Boat around"));
-    Serial.println(sysCalib_);
-    Serial.println(magCalib_);
-    Serial.println(accelCalib_);
-    Serial.println(gyroCalib_);
+    //Serial.println(F("Warning: Waiting for IMU to calibrate, please move Boat around"));
+    //Serial.println(sysCalib_);
+    //Serial.println(magCalib_);
+    //Serial.println(accelCalib_);
+    //Serial.println(gyroCalib_);
     bno_.getCalibration(&sysCalib_, &gyroCalib_, &accelCalib_, &magCalib_);
   }
 
 
-  /* Todo: Put in option to recalibrate
-  adafruit_bno055_offsets_t newCalib;
+  //Todo: Put in option to recalibrate
+  //adafruit_bno055_offsets_t newCalib;
 
-  bno_.getSensorOffsets(newCalib);
-  displaySensorOffsets(newCalib);
-  */
+  //bno_.getSensorOffsets(newCalib);
+  //displaySensorOffsets(newCalib);
+  //delay(5000);
+  
 }
 
 char* IMU::name()
@@ -191,10 +224,12 @@ void IMU::loop()
     lastMeasurementTime_ = millis();
 
 
+    /* Disable calibration warning - calibration status is returned in json reading anyway
     if (sysCalib_ < 3)
     {
       Serial.println("Warning poor IMU calibration");
     }
+    */
 
     char output_str[DEFAULT_BUFFER_SIZE + 3];
     snprintf(output_str, DEFAULT_BUFFER_SIZE,

--- a/firmware/Components.cpp
+++ b/firmware/Components.cpp
@@ -99,6 +99,7 @@ void AfroESC::arm()
   disable();
   delay(1000);
   velocity(0.0); //sends it 1500 for arming
+  delay(100);
   enable();
   delay(1000);
 }
@@ -159,15 +160,7 @@ IMU::IMU(int id, int interval)
 
   bno_.getCalibration(&sysCalib_, &gyroCalib_, &accelCalib_, &magCalib_);
 
-  /*
-  Accelerometer: 65525 65511 32 
-  Gyro: 65534 65534 0 
-  Mag: 65449 65443 261 
-  Accel Radius: 1000
-  Mag Radius: 709
-  */
-
-  /* Want to move this to EEPROM and put int option to recalibrate */
+  /* Need option to recalibrate - Current Values for Portugal */
   adafruit_bno055_offsets_t calib;
   calib.accel_offset_x = 65527;
   calib.accel_offset_y = 65450;
@@ -187,6 +180,7 @@ IMU::IMU(int id, int interval)
 
   // Wait until calibration values are within limits
   //while (!bno_.isFullyCalibrated())
+  // Looser requirement for faster arming. Should pause in server instead
   while (sysCalib_ < 3 || magCalib_ < 3)
   {
     delay(100);
@@ -223,14 +217,7 @@ void IMU::loop()
     bno_.getEvent(&event);
     lastMeasurementTime_ = millis();
 
-
-    /* Disable calibration warning - calibration status is returned in json reading anyway
-    if (sysCalib_ < 3)
-    {
-      Serial.println("Warning poor IMU calibration");
-    }
-    */
-
+    // Todo: return other values from imu as well
     char output_str[DEFAULT_BUFFER_SIZE + 3];
     snprintf(output_str, DEFAULT_BUFFER_SIZE,
              "{"
@@ -252,7 +239,7 @@ void IMU::loop()
 }
 
 AdafruitGPS::AdafruitGPS(int id, int port)
-  : ExternalSensor(id, port), SerialSensor(id, port, 9600, RS232, 0)
+  : ExternalSensor(id, port), SerialSensor(id, port, 9600, RS232, 0) // Should be TTL here?
 {
   // Note: This currently does not work after SerialSensor Init!
 

--- a/firmware/Platypus.cpp
+++ b/firmware/Platypus.cpp
@@ -337,6 +337,12 @@ Motor::~Motor()
 
 void Motor::velocity(float velocity)
 {
+	if (!enabled())
+		{
+			servo_.writeMicroseconds(motorCenter_);
+			return;
+		}
+	
   if (velocity > 1.0) {
     velocity = 1.0;
   }
@@ -360,8 +366,8 @@ void Motor::velocity(float velocity)
   }
   //float command = (velocity * 200) + 1500; //binding it from 1300 to 1700 because it sounds like there is damage being done at max 1900?
   servo_.writeMicroseconds(command);
-  // printf("velocity is: %d \n",velocity);
-  // printf("command is %d \n",command);
+	// printf("velocity is: %d \n",velocity);
+	// printf("command is %d \n",command);
 }
 
 // Deals with ESC softswitch exclusively

--- a/firmware/Platypus.cpp
+++ b/firmware/Platypus.cpp
@@ -1,16 +1,9 @@
 #include "Platypus.h"
 
-// Define for LEGACY support
-//#define LEGACY
-
-#ifndef LEGACY
 
 #include <Adafruit_NeoPixel.h>
 // LED serial controller.
-Adafruit_NeoPixel pixels = Adafruit_NeoPixel(board::NUM_LEDS, board::LED,
-                                             NEO_GRB + NEO_KHZ800);
-#endif
-
+Adafruit_NeoPixel pixels = Adafruit_NeoPixel(board::NUM_LEDS, board::LED, NEO_GRB + NEO_KHZ800);
 
 using namespace platypus;
 
@@ -116,24 +109,11 @@ void platypus::init()
 Led::Led()
   : r_(0), g_(0), b_(0)
 {
-#ifdef LEGACY
-  pinMode(board::LEGACY_LED.R, OUTPUT);
-  digitalWrite(board::LEGACY_LED.R, HIGH);
-  pinMode(board::LEGACY_LED.G, OUTPUT);
-  digitalWrite(board::LEGACY_LED.G, HIGH);
-  pinMode(board::LEGACY_LED.B, OUTPUT);
-  digitalWrite(board::LEGACY_LED.B, HIGH);
-#endif
-
 }
 
 Led::~Led()
 {
-#ifdef LEGACY
-  pinMode(board::LEGACY_LED.R, INPUT);
-  pinMode(board::LEGACY_LED.G, INPUT);
-  pinMode(board::LEGACY_LED.B, INPUT);
-#endif
+
 }
 
 void Led::set(int red, int green, int blue)
@@ -142,13 +122,6 @@ void Led::set(int red, int green, int blue)
   g_ = green;
   b_ = blue;
 
-#ifdef LEGACY
-
-  digitalWrite(board::LEGACY_LED.R, !r_);
-  digitalWrite(board::LEGACY_LED.G, !g_);
-  digitalWrite(board::LEGACY_LED.B, !b_);
-
-#endif
   /*
     while (!pixels.canShow());
     for (size_t pixel_idx = 0; pixel_idx < board::NUM_LEDS; ++pixel_idx)
@@ -262,17 +235,6 @@ bool EBoard::set(const char *param, const char *value)
     return false;
   }
   return true;
-}
-
-/*
-  These two are not implemented yet
-  Not sure if we will every need these for anything
-  but it might be useful for debugging or something
-  in the future
-*/
-void EBoard::onSerial()
-{
-  //onSerial not implemented yet
 }
 
 void EBoard::loop()

--- a/firmware/Platypus.cpp
+++ b/firmware/Platypus.cpp
@@ -8,7 +8,7 @@
 #include <Adafruit_NeoPixel.h>
 // LED serial controller.
 Adafruit_NeoPixel pixels = Adafruit_NeoPixel(board::NUM_LEDS, board::LED,
-											 NEO_GRB + NEO_KHZ800);
+                                             NEO_GRB + NEO_KHZ800);
 #endif
 
 
@@ -26,50 +26,50 @@ platypus::EBoard *platypus::eboard;
 
 // TODO: Switch to using HardwareSerial.
 USARTClass *platypus::SERIAL_PORTS[4] = {
-	&Serial1,
-	&Serial2,
-	&Serial3,
-	nullptr
+  &Serial1,
+  &Serial2,
+  &Serial3,
+  nullptr
 };
 
 SerialHandler_t platypus::SERIAL_HANDLERS[4] = {
-	{NULL, NULL},
-	{NULL, NULL},
-	{NULL, NULL},
-	{NULL, NULL}
+  {NULL, NULL},
+  {NULL, NULL},
+  {NULL, NULL},
+  {NULL, NULL}
 };
 
 
 void serialEvent1()
 {
-	if (SERIAL_HANDLERS[0].handler != NULL)
-	{
-		(*SERIAL_HANDLERS[0].handler)(SERIAL_HANDLERS[0].data);
-	}
+  if (SERIAL_HANDLERS[0].handler != NULL)
+  {
+    (*SERIAL_HANDLERS[0].handler)(SERIAL_HANDLERS[0].data);
+  }
 }
 
 void serialEvent2()
 {
-	if (SERIAL_HANDLERS[1].handler != NULL)
-	{
-		(*SERIAL_HANDLERS[1].handler)(SERIAL_HANDLERS[1].data);
-	}
+  if (SERIAL_HANDLERS[1].handler != NULL)
+  {
+    (*SERIAL_HANDLERS[1].handler)(SERIAL_HANDLERS[1].data);
+  }
 }
 
 void serialEvent3()
 {
-	if (SERIAL_HANDLERS[2].handler != NULL)
-	{
-		(*SERIAL_HANDLERS[2].handler)(SERIAL_HANDLERS[2].data);
-	}
+  if (SERIAL_HANDLERS[2].handler != NULL)
+  {
+    (*SERIAL_HANDLERS[2].handler)(SERIAL_HANDLERS[2].data);
+  }
 }
 
 uint32_t platypus::swap(uint32_t bytes)
 {
-	return ((bytes << 24) & 0xFF000000)
-	| ((bytes <<	8) & 0x00FF0000)
-	| ((bytes >>	8) & 0x0000FF00)
-	| ((bytes >> 24) & 0x000000FF);
+  return ((bytes << 24) & 0xFF000000)
+    | ((bytes <<  8) & 0x00FF0000)
+    | ((bytes >>  8) & 0x0000FF00)
+    | ((bytes >> 24) & 0x000000FF);
 }
 
 /**
@@ -77,52 +77,52 @@ uint32_t platypus::swap(uint32_t bytes)
  */
 void platypusLoop_()
 {
-	// TODO: Currently, this runs loops in series, which is wrong.
-	// TODO: Parallelize these cooperative loops.
+  // TODO: Currently, this runs loops in series, which is wrong.
+  // TODO: Parallelize these cooperative loops.
 
-	//Serial.println("In Platypus Loop");
+  //Serial.println("In Platypus Loop");
 
-	// Run each motor loop task once.
-	for (int motorIdx = 0; motorIdx < board::NUM_MOTORS; ++motorIdx)
-	{
-		Motor *motor = platypus::motors[motorIdx];
-		if (motor != NULL)
-		{
-			platypus::Motor::onLoop_(motor);
-		}
-	}
+  // Run each motor loop task once.
+  for (int motorIdx = 0; motorIdx < board::NUM_MOTORS; ++motorIdx)
+  {
+    Motor *motor = platypus::motors[motorIdx];
+    if (motor != NULL)
+    {
+      platypus::Motor::onLoop_(motor);
+    }
+  }
 
-	// Run each sensor loop task once.
-	for (int sensorIdx = 0; sensorIdx < board::NUM_SENSORS; ++sensorIdx)
-	{
-		Sensor *sensor = platypus::sensors[sensorIdx];
-		if (sensor != NULL)
-		{
-			platypus::Sensor::onLoop_(sensor);
-		}
-	}
+  // Run each sensor loop task once.
+  for (int sensorIdx = 0; sensorIdx < board::NUM_SENSORS; ++sensorIdx)
+  {
+    Sensor *sensor = platypus::sensors[sensorIdx];
+    if (sensor != NULL)
+    {
+      platypus::Sensor::onLoop_(sensor);
+    }
+  }
 
 
-	yield();
+  yield();
 }
 
 void platypus::init()
 {
-	Scheduler.startLoop(platypusLoop_);
-	//pixels.begin();
-	//pixels.show();
+  Scheduler.startLoop(platypusLoop_);
+  //pixels.begin();
+  //pixels.show();
 }
 
 Led::Led()
-	: r_(0), g_(0), b_(0)
+  : r_(0), g_(0), b_(0)
 {
 #ifdef LEGACY
-	pinMode(board::LEGACY_LED.R, OUTPUT);
-	digitalWrite(board::LEGACY_LED.R, HIGH);
-	pinMode(board::LEGACY_LED.G, OUTPUT);
-	digitalWrite(board::LEGACY_LED.G, HIGH);
-	pinMode(board::LEGACY_LED.B, OUTPUT);
-	digitalWrite(board::LEGACY_LED.B, HIGH);
+  pinMode(board::LEGACY_LED.R, OUTPUT);
+  digitalWrite(board::LEGACY_LED.R, HIGH);
+  pinMode(board::LEGACY_LED.G, OUTPUT);
+  digitalWrite(board::LEGACY_LED.G, HIGH);
+  pinMode(board::LEGACY_LED.B, OUTPUT);
+  digitalWrite(board::LEGACY_LED.B, HIGH);
 #endif
 
 }
@@ -130,525 +130,530 @@ Led::Led()
 Led::~Led()
 {
 #ifdef LEGACY
-	pinMode(board::LEGACY_LED.R, INPUT);
-	pinMode(board::LEGACY_LED.G, INPUT);
-	pinMode(board::LEGACY_LED.B, INPUT);
+  pinMode(board::LEGACY_LED.R, INPUT);
+  pinMode(board::LEGACY_LED.G, INPUT);
+  pinMode(board::LEGACY_LED.B, INPUT);
 #endif
 }
 
 void Led::set(int red, int green, int blue)
 {
-	r_ = red;
-	g_ = green;
-	b_ = blue;
+  r_ = red;
+  g_ = green;
+  b_ = blue;
 
 #ifdef LEGACY
 
-	digitalWrite(board::LEGACY_LED.R, !r_);
-	digitalWrite(board::LEGACY_LED.G, !g_);
-	digitalWrite(board::LEGACY_LED.B, !b_);
+  digitalWrite(board::LEGACY_LED.R, !r_);
+  digitalWrite(board::LEGACY_LED.G, !g_);
+  digitalWrite(board::LEGACY_LED.B, !b_);
 
 #endif
-	/*
-	while (!pixels.canShow());
-	for (size_t pixel_idx = 0; pixel_idx < board::NUM_LEDS; ++pixel_idx)
-	pixels.setPixelColor(pixel_idx, r_, g_, b_);
-	pixels.show();*/
+  /*
+    while (!pixels.canShow());
+    for (size_t pixel_idx = 0; pixel_idx < board::NUM_LEDS; ++pixel_idx)
+    pixels.setPixelColor(pixel_idx, r_, g_, b_);
+    pixels.show();*/
 }
 
 void Led::R(int red)
 {
-	set(red, g_, b_);
+  set(red, g_, b_);
 }
 
 int Led::R()
 {
-	return r_;
+  return r_;
 }
 
 void Led::G(int green)
 {
-	set(r_, green, b_);
+  set(r_, green, b_);
 }
 
 int Led::G()
 {
-	return g_;
+  return g_;
 }
 
 void Led::B(int blue)
 {
-	set(r_, g_, blue);
+  set(r_, g_, blue);
 }
 
 int Led::B()
 {
-	return b_;
+  return b_;
 }
 
 /*Make adk init use this not hard coded values at top of firmware*/
 EBoard::EBoard()
-	: applicationName_("Platypus Server"), accessoryName_("Platypus Control Board"), companyName_("Platypus LLC"), versionNumber_("3"), serialNumber_("3"), url_("http://senseplatypus.com")
+  : applicationName_("Platypus Server"), accessoryName_("Platypus Control Board"), companyName_("Platypus LLC"), versionNumber_("3"), serialNumber_("3"), url_("http://senseplatypus.com")
 {
-}
 
+}
+void EBoard::setState(SerialState state)
+{
+  state_ = state;
+}
+SerialState EBoard::getState()
+{
+  return state_;
+}
 EBoard::~EBoard()
 {
-	//Do i need to do anything here?
+  //Do i need to do anything here?
 }
 bool EBoard::set(const char *param, const char *value)
 {
-	if (strcmp("arm",param) == 0)
-	{
-		Serial.println("Arming Boat");
-		serial_state = SerialState::ACTIVE;
-	}
-	else if (strcmp("disarm",param) == 0)
-	{
-		Serial.println("Disarming Boat");
-		serial_state = SerialState::CONNECTED;
-	}
-	else if (strcmp("info",param) == 0)
-	{
-		char output_str[DEFAULT_BUFFER_SIZE];
-		String buffer;
-		if (strcmp("appName",value) == 0)
-		{
-			buffer = applicationName_;
-		}
-		else if (strcmp("accName",value) == 0)
-		{
-			buffer = accessoryName_;
-		}
-		else if (strcmp("cmpName",value) == 0)
-		{
-			buffer = companyName_;
-		}
-		else if (strcmp("vNum",value) == 0)
-		{
-			buffer = versionNumber_;
-		}
-		else if (strcmp("sNum",value) == 0)
-		{
-			buffer = serialNumber_;
-		}
-		else if (strcmp("url",value) == 0)
-		{
-			buffer = url_;
-		}
-		else
-		{
-			buffer = "Value not found";
-		}
-		snprintf(output_str,DEFAULT_BUFFER_SIZE,
-				 "{\"e\":{\"info:%s\"}}",buffer.c_str());
-		send(output_str);
-	}
-	else
-	{
-		return false;
-	}
-	return true;
+  if (strcmp("cmd",param) == 0)
+  {
+    if (strcmp("arm",value) == 0)
+    {
+      Serial.println("Arming Boat");
+      state_ = SerialState::ACTIVE;
+      Serial.println("STATE: ACTIVE");
+    }
+    else if (strcmp("disarm",value) == 0)
+    {
+      Serial.println("Disarming Boat");
+      state_ = SerialState::CONNECTED;
+      Serial.println("STATE: CONNECTED");
+    }
+  }
+
+  else if (strcmp("info",param) == 0)
+  {
+    char output_str[DEFAULT_BUFFER_SIZE];
+    String buffer;
+    if (strcmp("appName",value) == 0)
+    {
+      buffer = applicationName_;
+    }
+    else if (strcmp("accName",value) == 0)
+    {
+      buffer = accessoryName_;
+    }
+    else if (strcmp("cmpName",value) == 0)
+    {
+      buffer = companyName_;
+    }
+    else if (strcmp("vNum",value) == 0)
+    {
+      buffer = versionNumber_;
+    }
+    else if (strcmp("sNum",value) == 0)
+    {
+      buffer = serialNumber_;
+    }
+    else if (strcmp("url",value) == 0)
+    {
+      buffer = url_;
+    }
+    else
+    {
+      buffer = "Value not found";
+    }
+    snprintf(output_str,DEFAULT_BUFFER_SIZE,
+             "{\"e\":{\"info:%s\"}}",buffer.c_str());
+    send(output_str);
+  }
+  else
+  {
+    return false;
+  }
+  return true;
 }
 
 /*
-	These two are not implemented yet
-	Not sure if we will every need these for anything
-	but it might be useful for debugging or something
-	in the future
+  These two are not implemented yet
+  Not sure if we will every need these for anything
+  but it might be useful for debugging or something
+  in the future
 */
 void EBoard::onSerial()
 {
-	//onSerial not implemented yet
+  //onSerial not implemented yet
 }
 
 void EBoard::loop()
 {
-	//loop not implemented into scheduler yet
+  //loop not implemented into scheduler yet
 }
 
-SerialState EBoard::state()
-{
-	return serial_state;
-}
-
-void EBoard::disarm()
-{
-	/*Drops back into connected if in armed/active state*/
-	if (serial_state == SerialState::ACTIVE)
-	{
-		serial_state = SerialState::CONNECTED;
-	}
-}
-void EBoard::arm()
-{
-	serial_state == SerialState::ACTIVE;
-}
+// void EBoard::disarm()
+// {
+//  state = SerialState::CONNECTED;
+// }
+// void EBoard::arm()
+// {
+//  serial_state == SerialState::ACTIVE;
+// }
 
 Peripheral::Peripheral(int channel, bool enabled)
-	: channel_(channel), enable_(board::PERIPHERAL[channel].ENABLE)
+  : channel_(channel), enable_(board::PERIPHERAL[channel].ENABLE)
 {
-	pinMode(enable_, OUTPUT);
-	enable(enabled);
+  pinMode(enable_, OUTPUT);
+  enable(enabled);
 }
 
 Peripheral::~Peripheral()
 {
-	disable();
-	pinMode(enable_, INPUT);
+  disable();
+  pinMode(enable_, INPUT);
 }
 
 void Peripheral::enable(bool enabled)
 {
-	enabled_ = enabled;
-	digitalWrite(enable_, enabled);
+  enabled_ = enabled;
+  digitalWrite(enable_, enabled);
 }
 
 float Peripheral::current()
 {
-	float vsense = analogRead(board::PERIPHERAL[channel_].CURRENT);
-	//V sense is measured across a 330 Ohm resistor, I = V/R
-	//I sense is ~1/5000 of output current
-	return vsense*5000.0/330.0;
+  float vsense = analogRead(board::PERIPHERAL[channel_].CURRENT);
+  //V sense is measured across a 330 Ohm resistor, I = V/R
+  //I sense is ~1/5000 of output current
+  return vsense*5000.0/330.0;
 }
 
 Motor::Motor(int channel)
-	: channel_(channel), enable_(board::MOTOR[channel].ENABLE)
+  : channel_(channel), enable_(board::MOTOR[channel].ENABLE)
 {
-	// Initialize with ESC softswitch off
-	pinMode(enable_, OUTPUT);
-	disable();
+  // Initialize with ESC softswitch off
+  pinMode(enable_, OUTPUT);
+  disable();
 
-	// Attach Servo object to signal pin
-	servo_.attach(board::MOTOR[channel_].SERVO);
+  // Attach Servo object to signal pin
+  servo_.attach(board::MOTOR[channel_].SERVO);
 }
 
 Motor::~Motor()
 {
-	disable();
-	pinMode(enable_, INPUT);
-	servo_.detach();
+  disable();
+  pinMode(enable_, INPUT);
+  servo_.detach();
 }
 
 void Motor::velocity(float velocity)
 {
-	//Cap motor signals to between -1.0 and 1.0
-	if (velocity > 1.0) {
-	velocity = 1.0;
-	}
-	else if (velocity < -1.0) {
-	velocity = -1.0;
-	}
+  //Cap motor signals to between -1.0 and 1.0
+  if (velocity > 1.0) {
+    velocity = 1.0;
+  }
+  else if (velocity < -1.0) {
+    velocity = -1.0;
+  }
 
-	velocity_ = velocity;
+  velocity_ = velocity;
 
-	float command = (velocity * 500) + 1500;
-	servo_.writeMicroseconds(command);
+  float command = (velocity * 500) + 1500;
+  servo_.writeMicroseconds(command);
 }
 
 // Deals with ESC softswitch exclusively
 void Motor::enable(bool enabled)
 {
-	enabled_ = enabled;
-	digitalWrite(enable_, !enabled_);
+  enabled_ = enabled;
+  digitalWrite(enable_, !enabled_);
 
-	if (!enabled_)
-	{
-		velocity(0.0);
-	}
+  if (!enabled_)
+  {
+    velocity(0.0);
+  }
 }
 
 bool Motor::set(const char *param, const char *value)
 {
-	// Set motor velocity.
-	if (!strncmp("v", param, 2))
-	{
-		float v = atof(value);
+  // Set motor velocity.
+  if (!strncmp("v", param, 2))
+  {
+    float v = atof(value);
 
-		// Cap velocity command to between -1.0 and 1.0
-		if (v > 1.0) {
-		v = 1.0;
-		}
-		else if (v < -1.0) {
-		v = -1.0;
-		}
+    // Cap velocity command to between -1.0 and 1.0
+    if (v > 1.0) {
+      v = 1.0;
+    }
+    else if (v < -1.0) {
+      v = -1.0;
+    }
 
-		desiredVelocity_ = v;
+    desiredVelocity_ = v;
 
-		return true;
-	}
-	// Return false for unknown command.
-	else
-	{
-		return false;
-	}
+    return true;
+  }
+  // Return false for unknown command.
+  else
+  {
+    return false;
+  }
 }
 
 void Motor::loop()
 {
-	// At the desired velocity - Do nothing
-	if (abs(desiredVelocity_ - velocity_) < VELOCITY_THRESHOLD){
-	velocity(desiredVelocity_);
-	return;
-	}
+  // At the desired velocity - Do nothing
+  if (abs(desiredVelocity_ - velocity_) < VELOCITY_THRESHOLD){
+    velocity(desiredVelocity_);
+    return;
+  }
 
-	/*
-	// Scale
+  /*
+  // Scale
 
-	//New desired deadband around 0 - all commands under this magnitude map to 0
-	double deadBandSize = 0.001;
+  //New desired deadband around 0 - all commands under this magnitude map to 0
+  double deadBandSize = 0.001;
 
-	//Max safe reverse command
-	double reverseCommandLowerBound = -1.0;
-	//Min reverse command that will spin the motors
-	double reverseCommandUpperBound = -0.1;
+  //Max safe reverse command
+  double reverseCommandLowerBound = -1.0;
+  //Min reverse command that will spin the motors
+  double reverseCommandUpperBound = -0.1;
 
-	//Min forward command that will spin the motors
-	double forwardCommandLowerBound = 0.03;
-	//Max safe forward command
-	double forwardCommandUpperBound = 1.0;
+  //Min forward command that will spin the motors
+  double forwardCommandLowerBound = 0.03;
+  //Max safe forward command
+  double forwardCommandUpperBound = 1.0;
 
-	float v = desiredVelocity_;
+  float v = desiredVelocity_;
 
-	if (v < -deadBandSize){
-	v = (v + 1.0) * (reverseCommandUpperBound - reverseCommandLowerBound) + reverseCommandLowerBound;
-	} else if (v > deadBandSize){
-	v = v * (forwardCommandUpperBound - forwardCommandLowerBound) + forwardCommandLowerBound;
-	} else {
-	v = 0.0;
-	}*/
+  if (v < -deadBandSize){
+  v = (v + 1.0) * (reverseCommandUpperBound - reverseCommandLowerBound) + reverseCommandLowerBound;
+  } else if (v > deadBandSize){
+  v = v * (forwardCommandUpperBound - forwardCommandLowerBound) + forwardCommandLowerBound;
+  } else {
+  v = 0.0;
+  }*/
 
-	float v = (1.0 - VELOCITY_ALPHA) * velocity_ + VELOCITY_ALPHA * desiredVelocity_;
-	velocity(v);
+  float v = (1.0 - VELOCITY_ALPHA) * velocity_ + VELOCITY_ALPHA * desiredVelocity_;
+  velocity(v);
 
 }
 
 void Motor::onLoop_(void *data)
 {
-	// Resolve self-reference and call member function.
-	Motor *self = (Motor*)data;
-	self->loop();
+  // Resolve self-reference and call member function.
+  Motor *self = (Motor*)data;
+  self->loop();
 }
 
 Sensor::Sensor(int id) : id_(id)
 {
-	// Abstract Class - should not be instantiated
+  // Abstract Class - should not be instantiated
 }
 
 Sensor::~Sensor()
 {
-	// TODO: fill me in
+  // TODO: fill me in
 }
 
 bool Sensor::set(const char* param, const char* value)
 {
-	return false;
+  return false;
 }
 
 void Sensor::loop()
 {
-	// Default to doring nothing during loop function.
+  // Default to doring nothing during loop function.
 }
 
 void Sensor::onLoop_(void *data)
 {
-	// Resolve self-reference and call member function.
-	Sensor *self = (Sensor*)data;
-	self->loop();
+  // Resolve self-reference and call member function.
+  Sensor *self = (Sensor*)data;
+  self->loop();
 }
 
 ExternalSensor::ExternalSensor(int id, int port) : Sensor(id), port_(port)
 {
-	//Unknown if following code is necessary...
+  //Unknown if following code is necessary...
 
-	// Disable RSxxx receiver
-	pinMode(board::SENSOR_PORT[port].RX_DISABLE, OUTPUT);
-	digitalWrite(board::SENSOR_PORT[port].RX_DISABLE, HIGH);
+  // Disable RSxxx receiver
+  pinMode(board::SENSOR_PORT[port].RX_DISABLE, OUTPUT);
+  digitalWrite(board::SENSOR_PORT[port].RX_DISABLE, HIGH);
 
-	// Disable RSxxx transmitter
-	pinMode(board::SENSOR_PORT[port].TX_ENABLE, OUTPUT);
-	digitalWrite(board::SENSOR_PORT[port].TX_ENABLE, LOW);
+  // Disable RSxxx transmitter
+  pinMode(board::SENSOR_PORT[port].TX_ENABLE, OUTPUT);
+  digitalWrite(board::SENSOR_PORT[port].TX_ENABLE, LOW);
 
-	// Disable RS485 termination resistor
-	pinMode(board::SENSOR_PORT[port].RS485_TE, OUTPUT);
-	digitalWrite(board::SENSOR_PORT[port].RS485_TE, LOW);
+  // Disable RS485 termination resistor
+  pinMode(board::SENSOR_PORT[port].RS485_TE, OUTPUT);
+  digitalWrite(board::SENSOR_PORT[port].RS485_TE, LOW);
 
-	// Select RS232 (deselect RS485)
-	pinMode(board::SENSOR_PORT[port].RS485_232, OUTPUT);
-	digitalWrite(board::SENSOR_PORT[port].RS485_232, LOW);
+  // Select RS232 (deselect RS485)
+  pinMode(board::SENSOR_PORT[port].RS485_232, OUTPUT);
+  digitalWrite(board::SENSOR_PORT[port].RS485_232, LOW);
 
-	// TODO: deconflict this!
-	if (port < 2)
-	{
-		// Disable half-duplex
-		pinMode(board::HALF_DUPLEX01, OUTPUT);
-		digitalWrite(board::HALF_DUPLEX01, LOW);
-	}
-	else
-	{
-		// Disable half-duplex
-		pinMode(board::HALF_DUPLEX23, OUTPUT);
-		digitalWrite(board::HALF_DUPLEX23, LOW);
-	}
+  // TODO: deconflict this!
+  if (port < 2)
+  {
+    // Disable half-duplex
+    pinMode(board::HALF_DUPLEX01, OUTPUT);
+    digitalWrite(board::HALF_DUPLEX01, LOW);
+  }
+  else
+  {
+    // Disable half-duplex
+    pinMode(board::HALF_DUPLEX23, OUTPUT);
+    digitalWrite(board::HALF_DUPLEX23, LOW);
+  }
 
-	// Disable loopback test
-	pinMode(board::LOOPBACK, OUTPUT);
-	digitalWrite(board::LOOPBACK, LOW);
+  // Disable loopback test
+  pinMode(board::LOOPBACK, OUTPUT);
+  digitalWrite(board::LOOPBACK, LOW);
 
-	// Disable 12V output
-	pinMode(board::SENSOR_PORT[port].PWR_ENABLE, OUTPUT);
-	digitalWrite(board::SENSOR_PORT[port].PWR_ENABLE, LOW);
+  // Disable 12V output
+  pinMode(board::SENSOR_PORT[port].PWR_ENABLE, OUTPUT);
+  digitalWrite(board::SENSOR_PORT[port].PWR_ENABLE, LOW);
 }
 
 
 AnalogSensor::AnalogSensor(int id, int port)
-	: ExternalSensor(id, port), scale_(1.0f), offset_(0.0f) {}
+  : ExternalSensor(id, port), scale_(1.0f), offset_(0.0f) {}
 
 bool AnalogSensor::set(const char* param, const char* value)
 {
-	// Set analog scale.
-	if (!strncmp("scale", param, 6))
-	{
-		float s = atof(value);
-		scale(s);
-		return true;
-	}
-	// Set analog offset.
-	else if (!strncmp("offset", param, 7))
-	{
-		float o = atof(value);
-		offset(o);
-		return true;
-	}
-	// Return false for unknown command.
-	else
-	{
-		return false;
-	}
+  // Set analog scale.
+  if (!strncmp("scale", param, 6))
+  {
+    float s = atof(value);
+    scale(s);
+    return true;
+  }
+  // Set analog offset.
+  else if (!strncmp("offset", param, 7))
+  {
+    float o = atof(value);
+    offset(o);
+    return true;
+  }
+  // Return false for unknown command.
+  else
+  {
+    return false;
+  }
 }
 
 void AnalogSensor::scale(float scale)
 {
-	scale_ = scale;
+  scale_ = scale;
 }
 
 void AnalogSensor::offset(float offset)
 {
-	offset_ = offset;
+  offset_ = offset;
 }
 
 PoweredSensor::PoweredSensor(int id, int port, bool poweredOn)
-	: ExternalSensor(id, port), state_(true)
+  : ExternalSensor(id, port), state_(true)
 {
-	//PowerOff to be sure sensor is off
-	powerOff();
+  //PowerOff to be sure sensor is off
+  powerOff();
 
-	if (poweredOn){
-	powerOn();
-	} else {
-	powerOff();
-	}
+  if (poweredOn){
+    powerOn();
+  } else {
+    powerOff();
+  }
 }
 
 // Turn 12v pin on. Returns true if successful, false if power was already on
 bool PoweredSensor::powerOn(){
-	if (state_){
-	//Serial.println("Power On Failure, sensor already powered on");
-	return false;
-	} else {
-	pinMode(board::SENSOR_PORT[port_].PWR_ENABLE, OUTPUT);
-	digitalWrite(board::SENSOR_PORT[port_].PWR_ENABLE, HIGH);
-	state_ = true;
-	return true;
-	}
+  if (state_){
+    //Serial.println("Power On Failure, sensor already powered on");
+    return false;
+  } else {
+    pinMode(board::SENSOR_PORT[port_].PWR_ENABLE, OUTPUT);
+    digitalWrite(board::SENSOR_PORT[port_].PWR_ENABLE, HIGH);
+    state_ = true;
+    return true;
+  }
 }
 
 // Turn 12v pin off. Returns true if successful, false if power was already off
 bool PoweredSensor::powerOff(){
-	if (state_){
-	pinMode(board::SENSOR_PORT[port_].PWR_ENABLE, OUTPUT);
-	digitalWrite(board::SENSOR_PORT[port_].PWR_ENABLE, LOW);
-	state_ = false;
-	return true;
-	} else {
-	//Serial.println("Power Off Failure, sensor already powered off");
-	return false;
-	}
+  if (state_){
+    pinMode(board::SENSOR_PORT[port_].PWR_ENABLE, OUTPUT);
+    digitalWrite(board::SENSOR_PORT[port_].PWR_ENABLE, LOW);
+    state_ = false;
+    return true;
+  } else {
+    //Serial.println("Power Off Failure, sensor already powered off");
+    return false;
+  }
 }
 
 SerialSensor::SerialSensor(int id, int port, int baud, int type, int dataLength)
-	: ExternalSensor(id, port), recv_index_(0), baudRate_(baud), serialType_(type)
+  : ExternalSensor(id, port), recv_index_(0), baudRate_(baud), serialType_(type)
 {
-	minDataStringLength_ = dataLength;
+  minDataStringLength_ = dataLength;
 
-	if (type == RS485){
-	// Enable RSxxx receiver
-	pinMode(board::SENSOR_PORT[port].RX_DISABLE, OUTPUT);
-	digitalWrite(board::SENSOR_PORT[port].RX_DISABLE, LOW);
+  if (type == RS485){
+    // Enable RSxxx receiver
+    pinMode(board::SENSOR_PORT[port].RX_DISABLE, OUTPUT);
+    digitalWrite(board::SENSOR_PORT[port].RX_DISABLE, LOW);
 
-	// Enable RSxxx transmitter
-	pinMode(board::SENSOR_PORT[port].TX_ENABLE, OUTPUT);
-	digitalWrite(board::SENSOR_PORT[port].TX_ENABLE, HIGH);
+    // Enable RSxxx transmitter
+    pinMode(board::SENSOR_PORT[port].TX_ENABLE, OUTPUT);
+    digitalWrite(board::SENSOR_PORT[port].TX_ENABLE, HIGH);
 
-	// Enable RS485 termination resistor
-	pinMode(board::SENSOR_PORT[port].RS485_TE, OUTPUT);
-	digitalWrite(board::SENSOR_PORT[port].RS485_TE, HIGH);
+    // Enable RS485 termination resistor
+    pinMode(board::SENSOR_PORT[port].RS485_TE, OUTPUT);
+    digitalWrite(board::SENSOR_PORT[port].RS485_TE, HIGH);
 
-	// Select RS485 (deselect RS232)
-	pinMode(board::SENSOR_PORT[port].RS485_232, OUTPUT);
-	digitalWrite(board::SENSOR_PORT[port].RS485_232, HIGH);
-	}
+    // Select RS485 (deselect RS232)
+    pinMode(board::SENSOR_PORT[port].RS485_232, OUTPUT);
+    digitalWrite(board::SENSOR_PORT[port].RS485_232, HIGH);
+  }
 
-	if (SERIAL_PORTS[port] != nullptr)
-	{
-		// Register serial event handler
-		SerialHandler_t handler = {SerialSensor::onSerial_, this};
-		SERIAL_HANDLERS[port] = handler;
+  if (SERIAL_PORTS[port] != nullptr)
+  {
+    // Register serial event handler
+    SerialHandler_t handler = {SerialSensor::onSerial_, this};
+    SERIAL_HANDLERS[port] = handler;
 
-		SERIAL_PORTS[port]->begin(baud);
-	}
+    SERIAL_PORTS[port]->begin(baud);
+  }
 }
 
 void SerialSensor::onSerial(){
-	char c = SERIAL_PORTS[port_]->read();
+  char c = SERIAL_PORTS[port_]->read();
 
-	// Ignore null and tab characters
-	if (c == '\0' || c == '\t') {
-	return;
-	}
-	if (c != '\r' && c != '\n' && recv_index_ < DEFAULT_BUFFER_SIZE)
-	{
-		recv_buffer_[recv_index_] = c;
-		++recv_index_;
-	}
-	else if (recv_index_ > 0)
-	{
-		recv_buffer_[recv_index_] = '\0';
+  // Ignore null and tab characters
+  if (c == '\0' || c == '\t') {
+    return;
+  }
+  if (c != '\r' && c != '\n' && recv_index_ < DEFAULT_BUFFER_SIZE)
+  {
+    recv_buffer_[recv_index_] = c;
+    ++recv_index_;
+  }
+  else if (recv_index_ > 0)
+  {
+    recv_buffer_[recv_index_] = '\0';
 
-		if (recv_index_ >	 minDataStringLength_){
-		char output_str[DEFAULT_BUFFER_SIZE + 3];
-		snprintf(output_str, DEFAULT_BUFFER_SIZE,
-				 "{"
-				 "\"s%u\":{"
-				 "\"type\":\"%s\","
-				 "\"data\":\"%s\""
-				 "}"
-				 "}",
-				 id_,
-				 this->name(),
-				 recv_buffer_
-				 );
-		send(output_str);
-		}
+    if (recv_index_ >  minDataStringLength_){
+      char output_str[DEFAULT_BUFFER_SIZE + 3];
+      snprintf(output_str, DEFAULT_BUFFER_SIZE,
+               "{"
+               "\"s%u\":{"
+               "\"type\":\"%s\","
+               "\"data\":\"%s\""
+               "}"
+               "}",
+               id_,
+               this->name(),
+               recv_buffer_
+        );
+      send(output_str);
+    }
 
-		memset(recv_buffer_, 0, recv_index_);
-		recv_index_ = 0;
-	}
+    memset(recv_buffer_, 0, recv_index_);
+    recv_index_ = 0;
+  }
 }
 
 void SerialSensor::onSerial_(void *data)
 {
-	// Resolve self-reference and call member function.
-	SerialSensor *self = (SerialSensor*)data;
-	self->onSerial();
+  // Resolve self-reference and call member function.
+  SerialSensor *self = (SerialSensor*)data;
+  self->onSerial();
 }

--- a/firmware/Platypus.cpp
+++ b/firmware/Platypus.cpp
@@ -287,7 +287,14 @@ Motor::Motor(int channel,int motorMin,int motorMax,int motorCenter,int motorFDB,
   disable();
 
   // Attach Servo object to signal pin
-  servo_.attach(board::MOTOR[channel_].SERVO);
+	/* This is commented out to support changes to for BR thrusters
+		 Since velocity now sends 0 when !enabled, when the board boots 
+		 the pin is attached yet and not enabled, which will send a 0 command
+		 and then arm the motors. I think we can also just get rid of that !enabled
+		 statement in velocity since now when its not enabled it detaches that servo pin
+	*/
+  //servo_.attach(board::MOTOR[channel_].SERVO);
+
 }
 
 Motor::~Motor()
@@ -299,7 +306,7 @@ Motor::~Motor()
 
 void Motor::velocity(float velocity)
 {
-	if (!enabled())
+	if (!enabled()) //accidently arming boat on start
 		{
 			servo_.writeMicroseconds(motorCenter_);
 			return;

--- a/firmware/Platypus.cpp
+++ b/firmware/Platypus.cpp
@@ -202,7 +202,6 @@ SerialState EBoard::getState()
 }
 EBoard::~EBoard()
 {
-  //Do i need to do anything here?
 }
 bool EBoard::set(const char *param, const char *value)
 {

--- a/firmware/Platypus.cpp
+++ b/firmware/Platypus.cpp
@@ -8,7 +8,7 @@
 #include <Adafruit_NeoPixel.h>
 // LED serial controller.
 Adafruit_NeoPixel pixels = Adafruit_NeoPixel(board::NUM_LEDS, board::LED,
-                                             NEO_GRB + NEO_KHZ800);
+											 NEO_GRB + NEO_KHZ800);
 #endif
 
 
@@ -22,54 +22,54 @@ constexpr float VELOCITY_THRESHOLD = 0.001;
 platypus::Peripheral *platypus::peripherals[board::NUM_PERIPHERALS];
 platypus::Motor *platypus::motors[board::NUM_MOTORS];
 platypus::Sensor *platypus::sensors[board::NUM_SENSORS];
-
+platypus::EBoard *platypus::eboard;
 
 // TODO: Switch to using HardwareSerial.
 USARTClass *platypus::SERIAL_PORTS[4] = {
-  &Serial1,
-  &Serial2,
-  &Serial3,
-  nullptr
+	&Serial1,
+	&Serial2,
+	&Serial3,
+	nullptr
 };
 
 SerialHandler_t platypus::SERIAL_HANDLERS[4] = {
-  {NULL, NULL},
-  {NULL, NULL},
-  {NULL, NULL},
-  {NULL, NULL}
+	{NULL, NULL},
+	{NULL, NULL},
+	{NULL, NULL},
+	{NULL, NULL}
 };
 
 
-void serialEvent1() 
+void serialEvent1()
 {
-  if (SERIAL_HANDLERS[0].handler != NULL)
-  {
-    (*SERIAL_HANDLERS[0].handler)(SERIAL_HANDLERS[0].data);
-  }
+	if (SERIAL_HANDLERS[0].handler != NULL)
+	{
+		(*SERIAL_HANDLERS[0].handler)(SERIAL_HANDLERS[0].data);
+	}
 }
 
-void serialEvent2() 
+void serialEvent2()
 {
-  if (SERIAL_HANDLERS[1].handler != NULL)
-  {
-    (*SERIAL_HANDLERS[1].handler)(SERIAL_HANDLERS[1].data);
-  }
+	if (SERIAL_HANDLERS[1].handler != NULL)
+	{
+		(*SERIAL_HANDLERS[1].handler)(SERIAL_HANDLERS[1].data);
+	}
 }
 
-void serialEvent3() 
-{ 
-  if (SERIAL_HANDLERS[2].handler != NULL)
-  {
-    (*SERIAL_HANDLERS[2].handler)(SERIAL_HANDLERS[2].data);
-  }
+void serialEvent3()
+{
+	if (SERIAL_HANDLERS[2].handler != NULL)
+	{
+		(*SERIAL_HANDLERS[2].handler)(SERIAL_HANDLERS[2].data);
+	}
 }
 
 uint32_t platypus::swap(uint32_t bytes)
 {
-  return ((bytes << 24) & 0xFF000000)
-         | ((bytes <<  8) & 0x00FF0000)
-         | ((bytes >>  8) & 0x0000FF00)
-         | ((bytes >> 24) & 0x000000FF);
+	return ((bytes << 24) & 0xFF000000)
+	| ((bytes <<	8) & 0x00FF0000)
+	| ((bytes >>	8) & 0x0000FF00)
+	| ((bytes >> 24) & 0x000000FF);
 }
 
 /**
@@ -77,478 +77,578 @@ uint32_t platypus::swap(uint32_t bytes)
  */
 void platypusLoop_()
 {
-  // TODO: Currently, this runs loops in series, which is wrong.
-  // TODO: Parallelize these cooperative loops.
+	// TODO: Currently, this runs loops in series, which is wrong.
+	// TODO: Parallelize these cooperative loops.
 
-  //Serial.println("In Platypus Loop");
+	//Serial.println("In Platypus Loop");
 
-  // Run each motor loop task once.
-  for (int motorIdx = 0; motorIdx < board::NUM_MOTORS; ++motorIdx)
-  {
-    Motor *motor = platypus::motors[motorIdx];
-    if (motor != NULL)
-    {
-      platypus::Motor::onLoop_(motor);
-    }
-  }
+	// Run each motor loop task once.
+	for (int motorIdx = 0; motorIdx < board::NUM_MOTORS; ++motorIdx)
+	{
+		Motor *motor = platypus::motors[motorIdx];
+		if (motor != NULL)
+		{
+			platypus::Motor::onLoop_(motor);
+		}
+	}
 
-  // Run each sensor loop task once.  
-  for (int sensorIdx = 0; sensorIdx < board::NUM_SENSORS; ++sensorIdx)
-  {
-    Sensor *sensor = platypus::sensors[sensorIdx];
-    if (sensor != NULL) 
-    {
-      platypus::Sensor::onLoop_(sensor);
-    }
-  }
+	// Run each sensor loop task once.
+	for (int sensorIdx = 0; sensorIdx < board::NUM_SENSORS; ++sensorIdx)
+	{
+		Sensor *sensor = platypus::sensors[sensorIdx];
+		if (sensor != NULL)
+		{
+			platypus::Sensor::onLoop_(sensor);
+		}
+	}
 
-  yield();
+
+	yield();
 }
 
 void platypus::init()
 {
-  Scheduler.startLoop(platypusLoop_);
-  //pixels.begin();
-  //pixels.show();
+	Scheduler.startLoop(platypusLoop_);
+	//pixels.begin();
+	//pixels.show();
 }
 
 Led::Led()
-  : r_(0), g_(0), b_(0)
+	: r_(0), g_(0), b_(0)
 {
-  #ifdef LEGACY
-  pinMode(board::LEGACY_LED.R, OUTPUT);
-  digitalWrite(board::LEGACY_LED.R, HIGH);
-  pinMode(board::LEGACY_LED.G, OUTPUT);
-  digitalWrite(board::LEGACY_LED.G, HIGH);
-  pinMode(board::LEGACY_LED.B, OUTPUT);
-  digitalWrite(board::LEGACY_LED.B, HIGH);
-  #endif
+#ifdef LEGACY
+	pinMode(board::LEGACY_LED.R, OUTPUT);
+	digitalWrite(board::LEGACY_LED.R, HIGH);
+	pinMode(board::LEGACY_LED.G, OUTPUT);
+	digitalWrite(board::LEGACY_LED.G, HIGH);
+	pinMode(board::LEGACY_LED.B, OUTPUT);
+	digitalWrite(board::LEGACY_LED.B, HIGH);
+#endif
 
 }
 
 Led::~Led()
 {
-  #ifdef LEGACY
-  pinMode(board::LEGACY_LED.R, INPUT);
-  pinMode(board::LEGACY_LED.G, INPUT);
-  pinMode(board::LEGACY_LED.B, INPUT);
-  #endif
+#ifdef LEGACY
+	pinMode(board::LEGACY_LED.R, INPUT);
+	pinMode(board::LEGACY_LED.G, INPUT);
+	pinMode(board::LEGACY_LED.B, INPUT);
+#endif
 }
 
 void Led::set(int red, int green, int blue)
 {
-  r_ = red;
-  g_ = green;
-  b_ = blue;
+	r_ = red;
+	g_ = green;
+	b_ = blue;
 
-  #ifdef LEGACY
+#ifdef LEGACY
 
-  digitalWrite(board::LEGACY_LED.R, !r_);
-  digitalWrite(board::LEGACY_LED.G, !g_);
-  digitalWrite(board::LEGACY_LED.B, !b_);
+	digitalWrite(board::LEGACY_LED.R, !r_);
+	digitalWrite(board::LEGACY_LED.G, !g_);
+	digitalWrite(board::LEGACY_LED.B, !b_);
 
-  #endif
-  /*
-  while (!pixels.canShow());
-  for (size_t pixel_idx = 0; pixel_idx < board::NUM_LEDS; ++pixel_idx)
-    pixels.setPixelColor(pixel_idx, r_, g_, b_);
-  pixels.show();*/
+#endif
+	/*
+	while (!pixels.canShow());
+	for (size_t pixel_idx = 0; pixel_idx < board::NUM_LEDS; ++pixel_idx)
+	pixels.setPixelColor(pixel_idx, r_, g_, b_);
+	pixels.show();*/
 }
 
 void Led::R(int red)
 {
-  set(red, g_, b_);
+	set(red, g_, b_);
 }
 
 int Led::R()
 {
-  return r_;
+	return r_;
 }
 
 void Led::G(int green)
 {
-  set(r_, green, b_);
+	set(r_, green, b_);
 }
 
 int Led::G()
 {
-  return g_;
+	return g_;
 }
 
 void Led::B(int blue)
 {
-  set(r_, g_, blue);
+	set(r_, g_, blue);
 }
 
 int Led::B()
 {
-  return b_;
+	return b_;
+}
+
+/*Make adk init use this not hard coded values at top of firmware*/
+EBoard::EBoard()
+	: applicationName_("Platypus Server"), accessoryName_("Platypus Control Board"), companyName_("Platypus LLC"), versionNumber_("3"), serialNumber_("3"), url_("http://senseplatypus.com")
+{
+}
+
+EBoard::~EBoard()
+{
+	//Do i need to do anything here?
+}
+bool EBoard::set(const char *param, const char *value)
+{
+	if (strcmp("arm",param) == 0)
+	{
+		Serial.println("Arming Boat");
+		serial_state = SerialState::ACTIVE;
+	}
+	else if (strcmp("disarm",param) == 0)
+	{
+		Serial.println("Disarming Boat");
+		serial_state = SerialState::CONNECTED;
+	}
+	else if (strcmp("info",param) == 0)
+	{
+		char output_str[DEFAULT_BUFFER_SIZE];
+		String buffer;
+		if (strcmp("appName",value) == 0)
+		{
+			buffer = applicationName_;
+		}
+		else if (strcmp("accName",value) == 0)
+		{
+			buffer = accessoryName_;
+		}
+		else if (strcmp("cmpName",value) == 0)
+		{
+			buffer = companyName_;
+		}
+		else if (strcmp("vNum",value) == 0)
+		{
+			buffer = versionNumber_;
+		}
+		else if (strcmp("sNum",value) == 0)
+		{
+			buffer = serialNumber_;
+		}
+		else if (strcmp("url",value) == 0)
+		{
+			buffer = url_;
+		}
+		else
+		{
+			buffer = "Value not found";
+		}
+		snprintf(output_str,DEFAULT_BUFFER_SIZE,
+				 "{\"e\":{\"info:%s\"}}",buffer.c_str());
+		send(output_str);
+	}
+	else
+	{
+		return false;
+	}
+	return true;
+}
+
+/*
+	These two are not implemented yet
+	Not sure if we will every need these for anything
+	but it might be useful for debugging or something
+	in the future
+*/
+void EBoard::onSerial()
+{
+	//onSerial not implemented yet
+}
+
+void EBoard::loop()
+{
+	//loop not implemented into scheduler yet
+}
+
+SerialState EBoard::state()
+{
+	return serial_state;
+}
+
+void EBoard::disarm()
+{
+	/*Drops back into connected if in armed/active state*/
+	if (serial_state == SerialState::ACTIVE)
+	{
+		serial_state = SerialState::CONNECTED;
+	}
+}
+void EBoard::arm()
+{
+	serial_state == SerialState::ACTIVE;
 }
 
 Peripheral::Peripheral(int channel, bool enabled)
-  : channel_(channel), enable_(board::PERIPHERAL[channel].ENABLE)
+	: channel_(channel), enable_(board::PERIPHERAL[channel].ENABLE)
 {
-  pinMode(enable_, OUTPUT);
-  enable(enabled);
+	pinMode(enable_, OUTPUT);
+	enable(enabled);
 }
 
 Peripheral::~Peripheral()
 {
-  disable();
-  pinMode(enable_, INPUT);
+	disable();
+	pinMode(enable_, INPUT);
 }
 
 void Peripheral::enable(bool enabled)
 {
-  enabled_ = enabled;
-  digitalWrite(enable_, enabled);
+	enabled_ = enabled;
+	digitalWrite(enable_, enabled);
 }
 
 float Peripheral::current()
 {
-  float vsense = analogRead(board::PERIPHERAL[channel_].CURRENT);
-  //V sense is measured across a 330 Ohm resistor, I = V/R
-  //I sense is ~1/5000 of output current
-  return vsense*5000.0/330.0;
+	float vsense = analogRead(board::PERIPHERAL[channel_].CURRENT);
+	//V sense is measured across a 330 Ohm resistor, I = V/R
+	//I sense is ~1/5000 of output current
+	return vsense*5000.0/330.0;
 }
 
 Motor::Motor(int channel)
-  : channel_(channel), enable_(board::MOTOR[channel].ENABLE)
+	: channel_(channel), enable_(board::MOTOR[channel].ENABLE)
 {
-  // Initialize with ESC softswitch off
-  pinMode(enable_, OUTPUT);
-  disable();
+	// Initialize with ESC softswitch off
+	pinMode(enable_, OUTPUT);
+	disable();
 
-  // Attach Servo object to signal pin
-  servo_.attach(board::MOTOR[channel_].SERVO);
+	// Attach Servo object to signal pin
+	servo_.attach(board::MOTOR[channel_].SERVO);
 }
 
 Motor::~Motor()
 {
-  disable();
-  pinMode(enable_, INPUT);
-  servo_.detach();
+	disable();
+	pinMode(enable_, INPUT);
+	servo_.detach();
 }
 
 void Motor::velocity(float velocity)
 {
-  //Cap motor signals to between -1.0 and 1.0
-  if (velocity > 1.0) {
-    velocity = 1.0;
-  }
-  else if (velocity < -1.0) {
-    velocity = -1.0;
-  }
+	//Cap motor signals to between -1.0 and 1.0
+	if (velocity > 1.0) {
+	velocity = 1.0;
+	}
+	else if (velocity < -1.0) {
+	velocity = -1.0;
+	}
 
-  velocity_ = velocity;
+	velocity_ = velocity;
 
-  float command = (velocity * 500) + 1500;
-  servo_.writeMicroseconds(command);
+	float command = (velocity * 500) + 1500;
+	servo_.writeMicroseconds(command);
 }
 
 // Deals with ESC softswitch exclusively
 void Motor::enable(bool enabled)
 {
-  enabled_ = enabled;
-  digitalWrite(enable_, !enabled_);
+	enabled_ = enabled;
+	digitalWrite(enable_, !enabled_);
 
-  if (!enabled_)
-  {
-    velocity(0.0);
-  }
+	if (!enabled_)
+	{
+		velocity(0.0);
+	}
 }
 
 bool Motor::set(const char *param, const char *value)
 {
-  // Set motor velocity.
-  if (!strncmp("v", param, 2))
-  {
-    float v = atof(value);
+	// Set motor velocity.
+	if (!strncmp("v", param, 2))
+	{
+		float v = atof(value);
 
-    // Cap velocity command to between -1.0 and 1.0
-    if (v > 1.0) {
-      v = 1.0;
-    }
-    else if (v < -1.0) {
-      v = -1.0;
-    }
+		// Cap velocity command to between -1.0 and 1.0
+		if (v > 1.0) {
+		v = 1.0;
+		}
+		else if (v < -1.0) {
+		v = -1.0;
+		}
 
-    desiredVelocity_ = v;
-    
-    return true;
-  }
-  // Return false for unknown command.
-  else
-  {
-    return false;
-  }
+		desiredVelocity_ = v;
+
+		return true;
+	}
+	// Return false for unknown command.
+	else
+	{
+		return false;
+	}
 }
 
 void Motor::loop()
 {
-  // At the desired velocity - Do nothing
-  if (abs(desiredVelocity_ - velocity_) < VELOCITY_THRESHOLD){
-    velocity(desiredVelocity_);
-    return;
-  }
+	// At the desired velocity - Do nothing
+	if (abs(desiredVelocity_ - velocity_) < VELOCITY_THRESHOLD){
+	velocity(desiredVelocity_);
+	return;
+	}
 
-  /*
-  // Scale
+	/*
+	// Scale
 
-  //New desired deadband around 0 - all commands under this magnitude map to 0
-  double deadBandSize = 0.001;
+	//New desired deadband around 0 - all commands under this magnitude map to 0
+	double deadBandSize = 0.001;
 
-  //Max safe reverse command
-  double reverseCommandLowerBound = -1.0;
-  //Min reverse command that will spin the motors
-  double reverseCommandUpperBound = -0.1;
+	//Max safe reverse command
+	double reverseCommandLowerBound = -1.0;
+	//Min reverse command that will spin the motors
+	double reverseCommandUpperBound = -0.1;
 
-  //Min forward command that will spin the motors
-  double forwardCommandLowerBound = 0.03;
-  //Max safe forward command
-  double forwardCommandUpperBound = 1.0;
+	//Min forward command that will spin the motors
+	double forwardCommandLowerBound = 0.03;
+	//Max safe forward command
+	double forwardCommandUpperBound = 1.0;
 
-  float v = desiredVelocity_;
+	float v = desiredVelocity_;
 
-  if (v < -deadBandSize){
-    v = (v + 1.0) * (reverseCommandUpperBound - reverseCommandLowerBound) + reverseCommandLowerBound;
-  } else if (v > deadBandSize){
-    v = v * (forwardCommandUpperBound - forwardCommandLowerBound) + forwardCommandLowerBound;
-  } else {
-    v = 0.0;
-  }*/
+	if (v < -deadBandSize){
+	v = (v + 1.0) * (reverseCommandUpperBound - reverseCommandLowerBound) + reverseCommandLowerBound;
+	} else if (v > deadBandSize){
+	v = v * (forwardCommandUpperBound - forwardCommandLowerBound) + forwardCommandLowerBound;
+	} else {
+	v = 0.0;
+	}*/
 
-  float v = (1.0 - VELOCITY_ALPHA) * velocity_ + VELOCITY_ALPHA * desiredVelocity_;
-  velocity(v);
-  
+	float v = (1.0 - VELOCITY_ALPHA) * velocity_ + VELOCITY_ALPHA * desiredVelocity_;
+	velocity(v);
+
 }
 
 void Motor::onLoop_(void *data)
-{ 
-  // Resolve self-reference and call member function.
-  Motor *self = (Motor*)data;
-  self->loop();
+{
+	// Resolve self-reference and call member function.
+	Motor *self = (Motor*)data;
+	self->loop();
 }
 
 Sensor::Sensor(int id) : id_(id)
-{  
-  // Abstract Class - should not be instantiated
+{
+	// Abstract Class - should not be instantiated
 }
 
 Sensor::~Sensor()
 {
-  // TODO: fill me in
+	// TODO: fill me in
 }
 
 bool Sensor::set(const char* param, const char* value)
 {
-  return false;
+	return false;
 }
 
 void Sensor::loop()
 {
-  // Default to doring nothing during loop function.
+	// Default to doring nothing during loop function.
 }
 
 void Sensor::onLoop_(void *data)
-{ 
-  // Resolve self-reference and call member function.
-  Sensor *self = (Sensor*)data;
-  self->loop();
+{
+	// Resolve self-reference and call member function.
+	Sensor *self = (Sensor*)data;
+	self->loop();
 }
 
-ExternalSensor::ExternalSensor(int id, int port) : Sensor(id), port_(port) 
+ExternalSensor::ExternalSensor(int id, int port) : Sensor(id), port_(port)
 {
-  //Unknown if following code is necessary...
+	//Unknown if following code is necessary...
 
-  // Disable RSxxx receiver
-  pinMode(board::SENSOR_PORT[port].RX_DISABLE, OUTPUT);
-  digitalWrite(board::SENSOR_PORT[port].RX_DISABLE, HIGH);
+	// Disable RSxxx receiver
+	pinMode(board::SENSOR_PORT[port].RX_DISABLE, OUTPUT);
+	digitalWrite(board::SENSOR_PORT[port].RX_DISABLE, HIGH);
 
-  // Disable RSxxx transmitter
-  pinMode(board::SENSOR_PORT[port].TX_ENABLE, OUTPUT);
-  digitalWrite(board::SENSOR_PORT[port].TX_ENABLE, LOW);
+	// Disable RSxxx transmitter
+	pinMode(board::SENSOR_PORT[port].TX_ENABLE, OUTPUT);
+	digitalWrite(board::SENSOR_PORT[port].TX_ENABLE, LOW);
 
-  // Disable RS485 termination resistor
-  pinMode(board::SENSOR_PORT[port].RS485_TE, OUTPUT);
-  digitalWrite(board::SENSOR_PORT[port].RS485_TE, LOW);
+	// Disable RS485 termination resistor
+	pinMode(board::SENSOR_PORT[port].RS485_TE, OUTPUT);
+	digitalWrite(board::SENSOR_PORT[port].RS485_TE, LOW);
 
-  // Select RS232 (deselect RS485)
-  pinMode(board::SENSOR_PORT[port].RS485_232, OUTPUT);
-  digitalWrite(board::SENSOR_PORT[port].RS485_232, LOW);
+	// Select RS232 (deselect RS485)
+	pinMode(board::SENSOR_PORT[port].RS485_232, OUTPUT);
+	digitalWrite(board::SENSOR_PORT[port].RS485_232, LOW);
 
-  // TODO: deconflict this!
-  if (port < 2)
-  {
-    // Disable half-duplex
-    pinMode(board::HALF_DUPLEX01, OUTPUT);
-    digitalWrite(board::HALF_DUPLEX01, LOW);
-  } 
-  else 
-  {
-    // Disable half-duplex
-    pinMode(board::HALF_DUPLEX23, OUTPUT);
-    digitalWrite(board::HALF_DUPLEX23, LOW);
-  }
-  
-  // Disable loopback test
-  pinMode(board::LOOPBACK, OUTPUT);
-  digitalWrite(board::LOOPBACK, LOW);
-  
-  // Disable 12V output
-  pinMode(board::SENSOR_PORT[port].PWR_ENABLE, OUTPUT);
-  digitalWrite(board::SENSOR_PORT[port].PWR_ENABLE, LOW);
+	// TODO: deconflict this!
+	if (port < 2)
+	{
+		// Disable half-duplex
+		pinMode(board::HALF_DUPLEX01, OUTPUT);
+		digitalWrite(board::HALF_DUPLEX01, LOW);
+	}
+	else
+	{
+		// Disable half-duplex
+		pinMode(board::HALF_DUPLEX23, OUTPUT);
+		digitalWrite(board::HALF_DUPLEX23, LOW);
+	}
+
+	// Disable loopback test
+	pinMode(board::LOOPBACK, OUTPUT);
+	digitalWrite(board::LOOPBACK, LOW);
+
+	// Disable 12V output
+	pinMode(board::SENSOR_PORT[port].PWR_ENABLE, OUTPUT);
+	digitalWrite(board::SENSOR_PORT[port].PWR_ENABLE, LOW);
 }
 
 
 AnalogSensor::AnalogSensor(int id, int port)
-  : ExternalSensor(id, port), scale_(1.0f), offset_(0.0f) {}
+	: ExternalSensor(id, port), scale_(1.0f), offset_(0.0f) {}
 
 bool AnalogSensor::set(const char* param, const char* value)
 {
-  // Set analog scale.
-  if (!strncmp("scale", param, 6))
-  {
-    float s = atof(value);
-    scale(s);
-    return true;
-  }
-  // Set analog offset.
-  else if (!strncmp("offset", param, 7))
-  {
-    float o = atof(value);
-    offset(o);
-    return true;
-  }
-  // Return false for unknown command.
-  else
-  {
-    return false;
-  }
+	// Set analog scale.
+	if (!strncmp("scale", param, 6))
+	{
+		float s = atof(value);
+		scale(s);
+		return true;
+	}
+	// Set analog offset.
+	else if (!strncmp("offset", param, 7))
+	{
+		float o = atof(value);
+		offset(o);
+		return true;
+	}
+	// Return false for unknown command.
+	else
+	{
+		return false;
+	}
 }
 
 void AnalogSensor::scale(float scale)
 {
-  scale_ = scale;
+	scale_ = scale;
 }
 
 void AnalogSensor::offset(float offset)
 {
-  offset_ = offset;
+	offset_ = offset;
 }
 
 PoweredSensor::PoweredSensor(int id, int port, bool poweredOn)
-  : ExternalSensor(id, port), state_(true)
+	: ExternalSensor(id, port), state_(true)
 {
-  //PowerOff to be sure sensor is off
-  powerOff();
-  
-  if (poweredOn){
-    powerOn();
-  } else {
-    powerOff();
-  }
+	//PowerOff to be sure sensor is off
+	powerOff();
+
+	if (poweredOn){
+	powerOn();
+	} else {
+	powerOff();
+	}
 }
 
 // Turn 12v pin on. Returns true if successful, false if power was already on
 bool PoweredSensor::powerOn(){
-  if (state_){
-    //Serial.println("Power On Failure, sensor already powered on");
-    return false;
-  } else {
-    pinMode(board::SENSOR_PORT[port_].PWR_ENABLE, OUTPUT);
-    digitalWrite(board::SENSOR_PORT[port_].PWR_ENABLE, HIGH);
-    state_ = true;
-    return true;
-  }
+	if (state_){
+	//Serial.println("Power On Failure, sensor already powered on");
+	return false;
+	} else {
+	pinMode(board::SENSOR_PORT[port_].PWR_ENABLE, OUTPUT);
+	digitalWrite(board::SENSOR_PORT[port_].PWR_ENABLE, HIGH);
+	state_ = true;
+	return true;
+	}
 }
 
 // Turn 12v pin off. Returns true if successful, false if power was already off
 bool PoweredSensor::powerOff(){
-  if (state_){
-    pinMode(board::SENSOR_PORT[port_].PWR_ENABLE, OUTPUT);
-    digitalWrite(board::SENSOR_PORT[port_].PWR_ENABLE, LOW);
-    state_ = false;
-    return true;
-  } else {
-    //Serial.println("Power Off Failure, sensor already powered off");
-    return false;
-  }
+	if (state_){
+	pinMode(board::SENSOR_PORT[port_].PWR_ENABLE, OUTPUT);
+	digitalWrite(board::SENSOR_PORT[port_].PWR_ENABLE, LOW);
+	state_ = false;
+	return true;
+	} else {
+	//Serial.println("Power Off Failure, sensor already powered off");
+	return false;
+	}
 }
 
-SerialSensor::SerialSensor(int id, int port, int baud, int type, int dataLength) 
-  : ExternalSensor(id, port), recv_index_(0), baudRate_(baud), serialType_(type)
+SerialSensor::SerialSensor(int id, int port, int baud, int type, int dataLength)
+	: ExternalSensor(id, port), recv_index_(0), baudRate_(baud), serialType_(type)
 {
-  minDataStringLength_ = dataLength;
+	minDataStringLength_ = dataLength;
 
-  if (type == RS485){
-    // Enable RSxxx receiver
-    pinMode(board::SENSOR_PORT[port].RX_DISABLE, OUTPUT);
-    digitalWrite(board::SENSOR_PORT[port].RX_DISABLE, LOW);
-    
-    // Enable RSxxx transmitter
-    pinMode(board::SENSOR_PORT[port].TX_ENABLE, OUTPUT);
-    digitalWrite(board::SENSOR_PORT[port].TX_ENABLE, HIGH);
-    
-    // Enable RS485 termination resistor
-    pinMode(board::SENSOR_PORT[port].RS485_TE, OUTPUT);
-    digitalWrite(board::SENSOR_PORT[port].RS485_TE, HIGH);
-    
-    // Select RS485 (deselect RS232)
-    pinMode(board::SENSOR_PORT[port].RS485_232, OUTPUT);
-    digitalWrite(board::SENSOR_PORT[port].RS485_232, HIGH);
-  }
-  
-  if (SERIAL_PORTS[port] != nullptr)
-  {
-    // Register serial event handler
-    SerialHandler_t handler = {SerialSensor::onSerial_, this}; 
-    SERIAL_HANDLERS[port] = handler;
-    
-    SERIAL_PORTS[port]->begin(baud);
-  }
+	if (type == RS485){
+	// Enable RSxxx receiver
+	pinMode(board::SENSOR_PORT[port].RX_DISABLE, OUTPUT);
+	digitalWrite(board::SENSOR_PORT[port].RX_DISABLE, LOW);
+
+	// Enable RSxxx transmitter
+	pinMode(board::SENSOR_PORT[port].TX_ENABLE, OUTPUT);
+	digitalWrite(board::SENSOR_PORT[port].TX_ENABLE, HIGH);
+
+	// Enable RS485 termination resistor
+	pinMode(board::SENSOR_PORT[port].RS485_TE, OUTPUT);
+	digitalWrite(board::SENSOR_PORT[port].RS485_TE, HIGH);
+
+	// Select RS485 (deselect RS232)
+	pinMode(board::SENSOR_PORT[port].RS485_232, OUTPUT);
+	digitalWrite(board::SENSOR_PORT[port].RS485_232, HIGH);
+	}
+
+	if (SERIAL_PORTS[port] != nullptr)
+	{
+		// Register serial event handler
+		SerialHandler_t handler = {SerialSensor::onSerial_, this};
+		SERIAL_HANDLERS[port] = handler;
+
+		SERIAL_PORTS[port]->begin(baud);
+	}
 }
 
 void SerialSensor::onSerial(){
-  char c = SERIAL_PORTS[port_]->read();
-  
-  // Ignore null and tab characters
-  if (c == '\0' || c == '\t') {
-    return;
-  }
-  if (c != '\r' && c != '\n' && recv_index_ < DEFAULT_BUFFER_SIZE)
-  {
-    recv_buffer_[recv_index_] = c;
-    ++recv_index_;
-  }
-  else if (recv_index_ > 0)
-  {
-    recv_buffer_[recv_index_] = '\0';
+	char c = SERIAL_PORTS[port_]->read();
 
-    if (recv_index_ >  minDataStringLength_){
-      char output_str[DEFAULT_BUFFER_SIZE + 3];
-      snprintf(output_str, DEFAULT_BUFFER_SIZE,
-               "{"
-               "\"s%u\":{"
-               "\"type\":\"%s\","
-               "\"data\":\"%s\""
-               "}"
-               "}",
-               id_,
-               this->name(),
-               recv_buffer_
-              );
-      send(output_str);  
-    }
-    
-    memset(recv_buffer_, 0, recv_index_);
-    recv_index_ = 0;
-  }
+	// Ignore null and tab characters
+	if (c == '\0' || c == '\t') {
+	return;
+	}
+	if (c != '\r' && c != '\n' && recv_index_ < DEFAULT_BUFFER_SIZE)
+	{
+		recv_buffer_[recv_index_] = c;
+		++recv_index_;
+	}
+	else if (recv_index_ > 0)
+	{
+		recv_buffer_[recv_index_] = '\0';
+
+		if (recv_index_ >	 minDataStringLength_){
+		char output_str[DEFAULT_BUFFER_SIZE + 3];
+		snprintf(output_str, DEFAULT_BUFFER_SIZE,
+				 "{"
+				 "\"s%u\":{"
+				 "\"type\":\"%s\","
+				 "\"data\":\"%s\""
+				 "}"
+				 "}",
+				 id_,
+				 this->name(),
+				 recv_buffer_
+				 );
+		send(output_str);
+		}
+
+		memset(recv_buffer_, 0, recv_index_);
+		recv_index_ = 0;
+	}
 }
 
 void SerialSensor::onSerial_(void *data)
 {
-  // Resolve self-reference and call member function.
-  SerialSensor *self = (SerialSensor*)data;
-  self->onSerial();
+	// Resolve self-reference and call member function.
+	SerialSensor *self = (SerialSensor*)data;
+	self->onSerial();
 }

--- a/firmware/Platypus.h
+++ b/firmware/Platypus.h
@@ -117,8 +117,8 @@ namespace platypus
     void enable(bool enabled);
     bool enabled(){ return enabled_; };
 
-    void enable(){ enable(true); };
-    void disable(){ enable(false); };
+    void enable(){ enable(true); servo_.attach(board::MOTOR[channel_].SERVO);};
+    void disable(){ enable(false); servo_.detach();};
 
   private:
     Servo servo_;

--- a/firmware/Platypus.h
+++ b/firmware/Platypus.h
@@ -21,7 +21,7 @@ namespace platypus
   {
     /** Board is not armed, hasnt recieved any commands **/
     STANDBY,
-    /** Board recieved some commands or adk.isready(), there is a USB host present  **/
+    /** adk.isready(), there is a USB host present  **/
     CONNECTED,
     /** boat is getting and running commands **/
     ACTIVE

--- a/firmware/Platypus.h
+++ b/firmware/Platypus.h
@@ -84,12 +84,12 @@ namespace platypus
     EBoard();
     virtual ~EBoard();
     virtual bool set(const char *param, const char* value);
-    virtual void onSerial();
     virtual void loop();
     void disarm();
     void arm();
     void setState(SerialState state);
     SerialState getState();
+
   private:
     const String applicationName_;
     const String accessoryName_;

--- a/firmware/Platypus.h
+++ b/firmware/Platypus.h
@@ -15,225 +15,226 @@ extern void send(char *str);
 
 namespace platypus
 {
-	const int DEFAULT_BUFFER_SIZE = 128;
+  const int DEFAULT_BUFFER_SIZE = 128;
 
-	typedef enum class
-		{
-			/** Board is not armed, hasnt recieved any commands **/
-			STANDBY,
-			/** Board recieved some commands or adk.isready(), there is a USB host present	**/
-			CONNECTED,
-			/** boat is getting and running commands **/
-			ACTIVE
-		} SerialState;
+  typedef enum
+  {
+    /** Board is not armed, hasnt recieved any commands **/
+    STANDBY,
+    /** Board recieved some commands or adk.isready(), there is a USB host present  **/
+    CONNECTED,
+    /** boat is getting and running commands **/
+    ACTIVE
+  } SerialState;
 
-	// Main library initialization function.
-	void init();
+  // Main library initialization function.
+  void init();
 
-	class Configurable
-	{
-	public:
-		virtual bool set(const char *param, const char *value);
-	};
-	class Led
-	{
-	public:
-		Led();
-		virtual ~Led();
-		void set(int red, int green, int blue);
-		void R(int red);
-		int R();
-		void G(int green);
-		int G();
-		void B(int blue);
-		int B();
+  class Configurable
+  {
+  public:
+    virtual bool set(const char *param, const char *value);
+  };
+  class Led
+  {
+  public:
+    Led();
+    virtual ~Led();
+    void set(int red, int green, int blue);
+    void R(int red);
+    int R();
+    void G(int green);
+    int G();
+    void B(int blue);
+    int B();
 
-	private:
-		Led(const Led&);
-		Led& operator=(const Led&);
+  private:
+    Led(const Led&);
+    Led& operator=(const Led&);
 
-		int r_, g_, b_;
-	};
+    int r_, g_, b_;
+  };
 
-	class Peripheral
-	{
-	public:
-		// Initialize with power off by default
-		Peripheral(int channel, bool enabled = false);
-		virtual ~Peripheral();
+  class Peripheral
+  {
+  public:
+    // Initialize with power off by default
+    Peripheral(int channel, bool enabled = false);
+    virtual ~Peripheral();
 
-		// Functions to turn peripheral power on/off
-		void enable(bool enabled);
-		bool enabled(){ return enabled_; };
+    // Functions to turn peripheral power on/off
+    void enable(bool enabled);
+    bool enabled(){ return enabled_; };
 
-		void enable(){ enable(true); };
-		void disable(){ enable(false); };
+    void enable(){ enable(true); };
+    void disable(){ enable(false); };
 
-		// Get peripheral current use
-		float current();
+    // Get peripheral current use
+    float current();
 
-	private:
-		const int channel_;
-		const int enable_;
-		bool enabled_;
-	};
+  private:
+    const int channel_;
+    const int enable_;
+    bool enabled_;
+  };
 
-	class EBoard : public Configurable
-	{
-	public:
-		EBoard();
-		virtual ~EBoard();
-		virtual bool set(const char *param, const char* value);
-		virtual void onSerial();
-		virtual void loop();
-		SerialState state();
-		void disarm();
-		void arm();
-		SerialState serial_state = SerialState::STANDBY;
-	private:
-		const String applicationName_;
-		const String accessoryName_;
-		const String companyName_;
-		const String versionNumber_;
-		const String serialNumber_;
-		const String url_;
-	};
+  class EBoard : public Configurable
+  {
+  public:
+    EBoard();
+    virtual ~EBoard();
+    virtual bool set(const char *param, const char* value);
+    virtual void onSerial();
+    virtual void loop();
+    void disarm();
+    void arm();
+    void setState(SerialState state);
+    SerialState getState();
+  private:
+    const String applicationName_;
+    const String accessoryName_;
+    const String companyName_;
+    const String versionNumber_;
+    const String serialNumber_;
+    const String url_;
+    SerialState state_ = SerialState::STANDBY;
+  };
 
-	class Motor : public Configurable
-	{
-	public:
-		Motor(int channel);
-		virtual ~Motor();
+  class Motor : public Configurable
+  {
+  public:
+    Motor(int channel);
+    virtual ~Motor();
 
-		virtual void arm() = 0;
-		virtual bool set(const char *param, const char *value);
-		virtual void loop();
+    virtual void arm() = 0;
+    virtual bool set(const char *param, const char *value);
+    virtual void loop();
 
-		void velocity(float velocity);
-		float velocity(){ return velocity_; };
+    void velocity(float velocity);
+    float velocity(){ return velocity_; };
 
-		// Enable ESCs (softswitch)
-		void enable(bool enabled);
-		bool enabled(){ return enabled_; };
+    // Enable ESCs (softswitch)
+    void enable(bool enabled);
+    bool enabled(){ return enabled_; };
 
-		void enable(){ enable(true); };
-		void disable(){ enable(false); };
+    void enable(){ enable(true); };
+    void disable(){ enable(false); };
 
-	private:
-		Servo servo_;
-		const int channel_;
-		const int enable_;
-		bool enabled_;
-		float velocity_;
-		float desiredVelocity_;
+  private:
+    Servo servo_;
+    const int channel_;
+    const int enable_;
+    bool enabled_;
+    float velocity_;
+    float desiredVelocity_;
 
-	public:
-		static void onLoop_(void *data);
-	};
+  public:
+    static void onLoop_(void *data);
+  };
 
-	class Sensor : public Configurable
-	{
-	public:
-		Sensor(int id);
-		virtual ~Sensor();
+  class Sensor : public Configurable
+  {
+  public:
+    Sensor(int id);
+    virtual ~Sensor();
 
-		virtual bool set(const char* param, const char* value);
-		virtual char *name() = 0;
-		//virtual void onSerial();
-		virtual void loop();
+    virtual bool set(const char* param, const char* value);
+    virtual char *name() = 0;
+    //virtual void onSerial();
+    virtual void loop();
 
-	protected:
-		const int id_;
+  protected:
+    const int id_;
 
-	public:
-		//static void onSerial_(void *data);
-		static void onLoop_(void *data);
-		virtual void calibrate(int flag){};
-	};
+  public:
+    //static void onSerial_(void *data);
+    static void onLoop_(void *data);
+    virtual void calibrate(int flag){};
+  };
 
-	class ExternalSensor : public Sensor
-	{
-	public:
-		ExternalSensor(int id, int port);
-		virtual char	*name() = 0;
+  class ExternalSensor : public Sensor
+  {
+  public:
+    ExternalSensor(int id, int port);
+    virtual char  *name() = 0;
 
-	protected:
-		const int port_;
+  protected:
+    const int port_;
 
-	};
+  };
 
-	class AnalogSensor : public ExternalSensor
-	{
-	public:
-		AnalogSensor(int id, int port);
+  class AnalogSensor : public ExternalSensor
+  {
+  public:
+    AnalogSensor(int id, int port);
 
-		bool set(const char* param, const char* value);
-		virtual char *name() = 0;
+    bool set(const char* param, const char* value);
+    virtual char *name() = 0;
 
-		void scale(float scale);
-		float scale(){ return scale_; };
+    void scale(float scale);
+    float scale(){ return scale_; };
 
-		void offset(float offset);
-		float offset(){ return offset_; };
+    void offset(float offset);
+    float offset(){ return offset_; };
 
-	private:
-		float scale_;
-		float offset_;
-	};
+  private:
+    float scale_;
+    float offset_;
+  };
 
-	class PoweredSensor : virtual public ExternalSensor
-	{
-	public:
-		PoweredSensor(int id, int port, bool poweredOn=true);
-		virtual char *name() = 0;
-		bool powerOn();
-		bool powerOff();
+  class PoweredSensor : virtual public ExternalSensor
+  {
+  public:
+    PoweredSensor(int id, int port, bool poweredOn=true);
+    virtual char *name() = 0;
+    bool powerOn();
+    bool powerOff();
 
-	private:
-		bool state_;
-	};
+  private:
+    bool state_;
+  };
 
-	class SerialSensor : virtual public ExternalSensor
-	{
-	public:
-		SerialSensor(int id,	int port, int baud, int type = RS232, int dataLength = 0);
-		virtual char * name() = 0;
-		static void onSerial_(void *data);
-		void onSerial();
+  class SerialSensor : virtual public ExternalSensor
+  {
+  public:
+    SerialSensor(int id,  int port, int baud, int type = RS232, int dataLength = 0);
+    virtual char * name() = 0;
+    static void onSerial_(void *data);
+    void onSerial();
 
-		enum SERIAL_TYPE{
-			RS232,
-			RS485
-		};
+    enum SERIAL_TYPE{
+      RS232,
+      RS485
+    };
 
-	protected:
-		int baudRate_;
-		int serialType_;
-		int minDataStringLength_;
-		char recv_buffer_[DEFAULT_BUFFER_SIZE];
-		unsigned int recv_index_;
-	};
+  protected:
+    int baudRate_;
+    int serialType_;
+    int minDataStringLength_;
+    char recv_buffer_[DEFAULT_BUFFER_SIZE];
+    unsigned int recv_index_;
+  };
 
 
-	extern platypus::Motor *motors[board::NUM_MOTORS];
-	extern platypus::Sensor *sensors[board::NUM_SENSORS];
-	extern platypus::Peripheral *peripherals[board::NUM_PERIPHERALS];
-	extern platypus::EBoard *eboard;
+  extern platypus::Motor *motors[board::NUM_MOTORS];
+  extern platypus::Sensor *sensors[board::NUM_SENSORS];
+  extern platypus::Peripheral *peripherals[board::NUM_PERIPHERALS];
+  extern platypus::EBoard *eboard;
 
-	// Callbacks structure for serial events
-	typedef struct {
-		void (*handler)(void *arg);
-		void *data;
-	} SerialHandler_t;
+  // Callbacks structure for serial events
+  typedef struct {
+    void (*handler)(void *arg);
+    void *data;
+  } SerialHandler_t;
 
-	// Callbacks for serial events
-	extern SerialHandler_t SERIAL_HANDLERS[4];
+  // Callbacks for serial events
+  extern SerialHandler_t SERIAL_HANDLERS[4];
 
-	// Array of available serial ports
-	extern USARTClass *SERIAL_PORTS[4];
+  // Array of available serial ports
+  extern USARTClass *SERIAL_PORTS[4];
 
-	// Helper function to do endian conversion
-	uint32_t swap(uint32_t bytes);
+  // Helper function to do endian conversion
+  uint32_t swap(uint32_t bytes);
 }
 
 #endif //PLATYPUS_H

--- a/firmware/Platypus.h
+++ b/firmware/Platypus.h
@@ -15,225 +15,225 @@ extern void send(char *str);
 
 namespace platypus
 {
-  const int DEFAULT_BUFFER_SIZE = 128;
+	const int DEFAULT_BUFFER_SIZE = 128;
 
-  typedef enum class
-    {
-      /** Board is not armed, hasnt recieved any commands **/
-      STANDBY,
-      /** Board recieved some commands or adk.isready(), there is a USB host present  **/
-      CONNECTED,
-      /** boat is getting and running commands **/
-      ACTIVE
-    } SerialState;
+	typedef enum class
+		{
+			/** Board is not armed, hasnt recieved any commands **/
+			STANDBY,
+			/** Board recieved some commands or adk.isready(), there is a USB host present	**/
+			CONNECTED,
+			/** boat is getting and running commands **/
+			ACTIVE
+		} SerialState;
 
-  // Main library initialization function.
-  void init();
+	// Main library initialization function.
+	void init();
 
-  class Configurable
-  {
-  public:
-    virtual bool set(const char *param, const char *value);
-  };
-  class Led
-  {
-  public:
-    Led();
-    virtual ~Led();
-    void set(int red, int green, int blue);
-    void R(int red);
-    int R();
-    void G(int green);
-    int G();
-    void B(int blue);
-    int B();
+	class Configurable
+	{
+	public:
+		virtual bool set(const char *param, const char *value);
+	};
+	class Led
+	{
+	public:
+		Led();
+		virtual ~Led();
+		void set(int red, int green, int blue);
+		void R(int red);
+		int R();
+		void G(int green);
+		int G();
+		void B(int blue);
+		int B();
 
-  private:
-    Led(const Led&);
-    Led& operator=(const Led&);
+	private:
+		Led(const Led&);
+		Led& operator=(const Led&);
 
-    int r_, g_, b_;
-  };
+		int r_, g_, b_;
+	};
 
-  class Peripheral
-  {
-  public:
-    // Initialize with power off by default
-    Peripheral(int channel, bool enabled = false);
-    virtual ~Peripheral();
+	class Peripheral
+	{
+	public:
+		// Initialize with power off by default
+		Peripheral(int channel, bool enabled = false);
+		virtual ~Peripheral();
 
-    // Functions to turn peripheral power on/off
-    void enable(bool enabled);
-    bool enabled(){ return enabled_; };
+		// Functions to turn peripheral power on/off
+		void enable(bool enabled);
+		bool enabled(){ return enabled_; };
 
-    void enable(){ enable(true); };
-    void disable(){ enable(false); };
+		void enable(){ enable(true); };
+		void disable(){ enable(false); };
 
-    // Get peripheral current use
-    float current();
+		// Get peripheral current use
+		float current();
 
-  private:
-    const int channel_;
-    const int enable_;
-    bool enabled_;
-  };
+	private:
+		const int channel_;
+		const int enable_;
+		bool enabled_;
+	};
 
-  class EBoard : public Configurable
-  {
-  public:
-    EBoard();
-    virtual ~EBoard();
-    virtual bool set(const char *param, const char* value);
-    virtual void onSerial();
-    virtual void loop();
-    SerialState state();
-    void disarm();
-    void arm();
-    SerialState serial_state = SerialState::STANDBY;
-  private:
-    const String applicationName_;
-    const String accessoryName_;
-    const String companyName_;
-    const String versionNumber_;
-    const String serialNumber_;
-    const String url_;
-  };
+	class EBoard : public Configurable
+	{
+	public:
+		EBoard();
+		virtual ~EBoard();
+		virtual bool set(const char *param, const char* value);
+		virtual void onSerial();
+		virtual void loop();
+		SerialState state();
+		void disarm();
+		void arm();
+		SerialState serial_state = SerialState::STANDBY;
+	private:
+		const String applicationName_;
+		const String accessoryName_;
+		const String companyName_;
+		const String versionNumber_;
+		const String serialNumber_;
+		const String url_;
+	};
 
-  class Motor : public Configurable
-  {
-  public:
-    Motor(int channel);
-    virtual ~Motor();
+	class Motor : public Configurable
+	{
+	public:
+		Motor(int channel);
+		virtual ~Motor();
 
-    virtual void arm() = 0;
-    virtual bool set(const char *param, const char *value);
-    virtual void loop();
+		virtual void arm() = 0;
+		virtual bool set(const char *param, const char *value);
+		virtual void loop();
 
-    void velocity(float velocity);
-    float velocity(){ return velocity_; };
+		void velocity(float velocity);
+		float velocity(){ return velocity_; };
 
-    // Enable ESCs (softswitch)
-    void enable(bool enabled);
-    bool enabled(){ return enabled_; };
+		// Enable ESCs (softswitch)
+		void enable(bool enabled);
+		bool enabled(){ return enabled_; };
 
-    void enable(){ enable(true); };
-    void disable(){ enable(false); };
+		void enable(){ enable(true); };
+		void disable(){ enable(false); };
 
-  private:
-    Servo servo_;
-    const int channel_;
-    const int enable_;
-    bool enabled_;
-    float velocity_;
-    float desiredVelocity_;
+	private:
+		Servo servo_;
+		const int channel_;
+		const int enable_;
+		bool enabled_;
+		float velocity_;
+		float desiredVelocity_;
 
-  public:
-    static void onLoop_(void *data);
-  };
+	public:
+		static void onLoop_(void *data);
+	};
 
-  class Sensor : public Configurable
-  {
-  public:
-    Sensor(int id);
-    virtual ~Sensor();
+	class Sensor : public Configurable
+	{
+	public:
+		Sensor(int id);
+		virtual ~Sensor();
 
-    virtual bool set(const char* param, const char* value);
-    virtual char *name() = 0;
-    //virtual void onSerial();
-    virtual void loop();
+		virtual bool set(const char* param, const char* value);
+		virtual char *name() = 0;
+		//virtual void onSerial();
+		virtual void loop();
 
-  protected:
-    const int id_;
+	protected:
+		const int id_;
 
-  public:
-    //static void onSerial_(void *data);
-    static void onLoop_(void *data);
-    virtual void calibrate(int flag){};
-  };
+	public:
+		//static void onSerial_(void *data);
+		static void onLoop_(void *data);
+		virtual void calibrate(int flag){};
+	};
 
-  class ExternalSensor : public Sensor
-  {
-  public:
-    ExternalSensor(int id, int port);
-    virtual char  *name() = 0;
+	class ExternalSensor : public Sensor
+	{
+	public:
+		ExternalSensor(int id, int port);
+		virtual char	*name() = 0;
 
-  protected:
-    const int port_;
+	protected:
+		const int port_;
 
-  };
+	};
 
-  class AnalogSensor : public ExternalSensor
-  {
-  public:
-    AnalogSensor(int id, int port);
+	class AnalogSensor : public ExternalSensor
+	{
+	public:
+		AnalogSensor(int id, int port);
 
-    bool set(const char* param, const char* value);
-    virtual char *name() = 0;
+		bool set(const char* param, const char* value);
+		virtual char *name() = 0;
 
-    void scale(float scale);
-    float scale(){ return scale_; };
+		void scale(float scale);
+		float scale(){ return scale_; };
 
-    void offset(float offset);
-    float offset(){ return offset_; };
+		void offset(float offset);
+		float offset(){ return offset_; };
 
-  private:
-    float scale_;
-    float offset_;
-  };
+	private:
+		float scale_;
+		float offset_;
+	};
 
-  class PoweredSensor : virtual public ExternalSensor
-  {
-  public:
-    PoweredSensor(int id, int port, bool poweredOn=true);
-    virtual char *name() = 0;
-    bool powerOn();
-    bool powerOff();
+	class PoweredSensor : virtual public ExternalSensor
+	{
+	public:
+		PoweredSensor(int id, int port, bool poweredOn=true);
+		virtual char *name() = 0;
+		bool powerOn();
+		bool powerOff();
 
-  private:
-    bool state_;
-  };
+	private:
+		bool state_;
+	};
 
-  class SerialSensor : virtual public ExternalSensor
-  {
-  public:
-    SerialSensor(int id,  int port, int baud, int type = RS232, int dataLength = 0);
-    virtual char * name() = 0;
-    static void onSerial_(void *data);
-    void onSerial();
+	class SerialSensor : virtual public ExternalSensor
+	{
+	public:
+		SerialSensor(int id,	int port, int baud, int type = RS232, int dataLength = 0);
+		virtual char * name() = 0;
+		static void onSerial_(void *data);
+		void onSerial();
 
-    enum SERIAL_TYPE{
-      RS232,
-      RS485
-    };
+		enum SERIAL_TYPE{
+			RS232,
+			RS485
+		};
 
-  protected:
-    int baudRate_;
-    int serialType_;
-    int minDataStringLength_;
-    char recv_buffer_[DEFAULT_BUFFER_SIZE];
-    unsigned int recv_index_;
-  };
+	protected:
+		int baudRate_;
+		int serialType_;
+		int minDataStringLength_;
+		char recv_buffer_[DEFAULT_BUFFER_SIZE];
+		unsigned int recv_index_;
+	};
 
 
-  extern platypus::Motor *motors[board::NUM_MOTORS];
-  extern platypus::Sensor *sensors[board::NUM_SENSORS];
-  extern platypus::Peripheral *peripherals[board::NUM_PERIPHERALS];
-  extern platypus::EBoard *eboard;
+	extern platypus::Motor *motors[board::NUM_MOTORS];
+	extern platypus::Sensor *sensors[board::NUM_SENSORS];
+	extern platypus::Peripheral *peripherals[board::NUM_PERIPHERALS];
+	extern platypus::EBoard *eboard;
 
-  // Callbacks structure for serial events
-  typedef struct {
-    void (*handler)(void *arg);
-    void *data;
-  } SerialHandler_t;
+	// Callbacks structure for serial events
+	typedef struct {
+		void (*handler)(void *arg);
+		void *data;
+	} SerialHandler_t;
 
-  // Callbacks for serial events
-  extern SerialHandler_t SERIAL_HANDLERS[4];
+	// Callbacks for serial events
+	extern SerialHandler_t SERIAL_HANDLERS[4];
 
-  // Array of available serial ports
-  extern USARTClass *SERIAL_PORTS[4];
+	// Array of available serial ports
+	extern USARTClass *SERIAL_PORTS[4];
 
-  // Helper function to do endian conversion
-  uint32_t swap(uint32_t bytes);
+	// Helper function to do endian conversion
+	uint32_t swap(uint32_t bytes);
 }
 
 #endif //PLATYPUS_H

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -202,8 +202,9 @@ void setup()
   // Set ADC Precision:
   analogReadResolution(12);
 
-  /*
+  
   // Set GPS Settings
+  
   Serial1.begin(9600);
   Serial1.setTimeout(250);
   // Set output to RMC only
@@ -214,7 +215,8 @@ void setup()
   // Set fix rate to 5Hz
   Serial1.println(PMTK_SET_NMEA_UPDATE_5HZ);
   Serial1.flush();
-  */
+  
+  
 
   // Initialize EBoard object
   platypus::eboard = new platypus::EBoard();
@@ -252,14 +254,14 @@ void setup()
   platypus::init();
 
   // Print header indicating that board successfully initialized
-
+  /* Disable info print for now
   Serial.println(F("------------------------------"));
   Serial.println(companyName);
   Serial.println(url);
   Serial.println(accessoryName);
   Serial.println(versionNumber);
   Serial.println(F("------------------------------"));
-
+  */
   // Turn LED to startup state.
   rgb_led.set(255, 0, 255);
   delay(1000);
@@ -277,7 +279,7 @@ void loop()
 			if (platypus::eboard->getState() == SerialState::ACTIVE)
 				{
 					platypus::eboard->setState(SerialState::CONNECTED);
-					Serial.println("STATE: CONNECTED");
+					//Serial.println("STATE: CONNECTED");
 					yield();
 					return;
 				}
@@ -289,7 +291,7 @@ void loop()
 		if (platypus::eboard->getState() == SerialState::CONNECTED)
 		{
 			platypus::eboard->setState(SerialState::STANDBY);
-			Serial.println("STATE: STANDBY");
+			//Serial.println("STATE: STANDBY");
 		}
 		yield();
 		return;
@@ -300,7 +302,7 @@ void loop()
 		if (platypus::eboard->getState() == SerialState::STANDBY)
 		{
 			platypus::eboard->setState(SerialState::CONNECTED);
-			Serial.println("STATE: CONNECTED1");
+			//Serial.println("STATE: CONNECTED1");
 		}
 	}
 	yield();
@@ -469,7 +471,7 @@ void ADKLoop()
         if (platypus::eboard->getState() != SerialState::ACTIVE)
         {
           platypus::eboard->setState(SerialState::ACTIVE);
-          Serial.println("STATE: ACTIVE");
+          //Serial.println("STATE: ACTIVE");
         }
         handleCommand(input_buffer);
       }

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -13,7 +13,13 @@
 // TODO: remove me
 #include "Board.h"
 
-// ADK USB Host configuration 
+//Typedefs
+typedef platypus::SerialState SerialState;
+
+
+
+// ADK USB Host configuration
+/* Make server accept version 4.x.x */
 char applicationName[] = "Platypus Server"; // the app on Android
 char accessoryName[] = "Platypus Control Board"; // your Arduino board
 char companyName[] = "Platypus LLC";
@@ -27,8 +33,8 @@ char boardVersion[] = "4.2.0";
 
 
 #define PMTK_SET_NMEA_OUTPUT_RMCONLY "$PMTK314,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*29"
-#define PMTK_SET_NMEA_UPDATE_5HZ  "$PMTK220,200*2C"
-#define PMTK_API_SET_FIX_CTL_5HZ  "$PMTK300,200,0,0,0,0*2F"
+#define PMTK_SET_NMEA_UPDATE_5HZ	"$PMTK220,200*2C"
+#define PMTK_API_SET_FIX_CTL_5HZ	"$PMTK300,200,0,0,0,0*2F"
 
 
 // ADK USB Host
@@ -43,17 +49,11 @@ char debug_buffer[INPUT_BUFFER_SIZE+1];
 const size_t OUTPUT_BUFFER_SIZE = 576;
 char output_buffer[OUTPUT_BUFFER_SIZE+3];
 
+static unsigned long last_command_time = 0;
+static unsigned long time_at_connected = 0;
+
 // System state enumeration
-enum SystemState
-{
-  /** There is no ADK USB device currently plugged in. */
-  DISCONNECTED,
-  /** There is an ADK USB device detected, but it is unresponsive. */
-  CONNECTED,
-  /** There is a Platypus Server currently communicating. */
-  RUNNING  
-};
-SystemState system_state = DISCONNECTED;
+SerialState serial_state = SerialState::STANDBY;
 
 // Time betweeen commands before we consider the Android
 // server to be unresponsive.
@@ -62,6 +62,7 @@ const size_t RESPONSE_TIMEOUT_MS = 500;
 // Time to wait before dropping into DISCONNECTED state when USB cable is disconnected
 // Deals with dodgy USB connections and improves USB C support for all cables
 const size_t CONNECTION_TIMEOUT_MS = 500;
+const size_t CONNECT_STANDBY_TIMEOUT = 3000;
 
 // Define the systems on this board
 // TODO: move this board.h?
@@ -71,21 +72,20 @@ platypus::Led rgb_led;
  * Wrapper for ADK send command that copies data to debug port.
  * Requires a null-terminated char* pointer.
  */
-void send(char *str) 
-{ 
-  // Add newline termination
-  // TODO: Make sure we don't buffer overflow
-  size_t len = strlen(str);
-  str[len++] = '\r';
-  str[len++] = '\n';
-  str[len] = '\0';
-  
-  // Write string to USB.
-  if (adk.isReady()) adk.write(len, (uint8_t*)str);
-  
-  // Copy string to debugging console.
-  Serial.print("-> ");
-  Serial.print(str);
+void send(char *str)
+{
+	// Add newline termination
+	// TODO: Make sure we don't buffer overflow
+	size_t len = strlen(str);
+	str[len++] = '\r';
+	str[len++] = '\n';
+	str[len] = '\0';
+
+	// Write string to USB.
+	if (adk.isReady()) adk.write(len, (uint8_t*)str);
+	// Copy string to debugging console.
+	Serial.print("-> ");
+	Serial.print(str);
 }
 
 /**
@@ -94,14 +94,14 @@ void send(char *str)
  */
 void reportError(const char *error_message, const char *buffer)
 {
-  // Construct a JSON error message.
-  snprintf(output_buffer, OUTPUT_BUFFER_SIZE, 
-           "{"
-           "\"error\": \"%s\","
-           "\"args\": \"%s\""
-           "}",
-           error_message, buffer);
-  send(output_buffer);
+	// Construct a JSON error message.
+	snprintf(output_buffer, OUTPUT_BUFFER_SIZE,
+					 "{"
+					 "\"error\": \"%s\","
+					 "\"args\": \"%s\""
+					 "}",
+					 error_message, buffer);
+	send(output_buffer);
 }
 
 /**
@@ -110,370 +110,359 @@ void reportError(const char *error_message, const char *buffer)
  */
 void handleCommand(char *buffer)
 {
-  // Allocate buffer for JSON parsing
-  StaticJsonBuffer<200> jsonBuffer;
+	// Allocate buffer for JSON parsing
+	StaticJsonBuffer<200> jsonBuffer;
 
-  // Attempt to parse JSON in buffer
-  JsonObject& command = jsonBuffer.parseObject(buffer);
+	// Attempt to parse JSON in buffer
+	JsonObject& command = jsonBuffer.parseObject(buffer);
 
-  // Check for parsing error
-  if (!command.success())
-  {
-    // Parsing Failure 
-    reportError("Failed to parse JSON command.", buffer);
-    return;
-  }
+	// Check for parsing error
+	if (!command.success())
+		{
+			// Parsing Failure
+			reportError("Failed to parse JSON command.", buffer);
+			return;
+		}
 
-  for (JsonObject::iterator it=command.begin(); it!=command.end(); ++it)
-  {
-    const char * key = it->key;
-    
-    platypus::Configurable * target_object;
-    size_t object_index;
+	for (JsonObject::iterator it=command.begin(); it!=command.end(); ++it)
+		{
+			const char * key = it->key;
 
-    // Determine target object
-    switch (key[0]){
-    case 'm': // Motor command
-      object_index = key[1] - '0';
+			platypus::Configurable * target_object;
+			size_t object_index;
 
-      if (object_index >= board::NUM_MOTORS){
-        reportError("Invalid motor index.", buffer);
-        return;
-      }
+			// Determine target object
+			switch (key[0]){
+			case 'm': // Motor command
+				object_index = key[1] - '0';
 
-      target_object = platypus::motors[object_index];
-      break;
-      
-    case 's': // Sensor command
-      object_index = key[1] - '0';
+				if (object_index >= board::NUM_MOTORS){
+					reportError("Invalid motor index.", buffer);
+					return;
+				}
 
-      if (object_index >= board::NUM_SENSORS){
-        reportError("Invalid sensor index.", buffer);
-        return;
-      }
+				target_object = platypus::motors[object_index];
+				break;
 
-      target_object = platypus::sensors[object_index];
-      break;
+			case 's': // Sensor command
+				object_index = key[1] - '0';
 
-    default: // Unrecognized target
-      reportError("Unknown command target.", buffer);
-      return;
-    }
+				if (object_index >= board::NUM_SENSORS){
+					reportError("Invalid sensor index.", buffer);
+					return;
+				}
+				target_object = platypus::sensors[object_index];
+				break;
 
-    // Extract JsonObject with param:value pairs
-    JsonObject& params = it->value;
+			case 'e': //eboard command
+				target_object = platypus::eboard;
+				break;
 
-    // Todo: Move this parsing to specific components and pass ref to params instead
-    // Iterate over and set parameter:value pairs on target object
-    for (JsonObject::iterator paramIt=params.begin(); paramIt!=params.end(); ++paramIt)
-    {
-      const char * param_name = paramIt->key;
-      const char * param_value = paramIt->value;
+			default: // Unrecognized target
+				reportError("Unknown command target.", buffer);
+				return;
+			}
 
-      /* Debugging Output
-      Serial.print("Sending command to ");
-      Serial.print(key);
-      Serial.print(": ");
-      Serial.print(param_name);
-      Serial.print(" : ");
-      Serial.println(param_value);
-      */
+			// Extract JsonObject with param:value pairs
+			JsonObject& params = it->value;
+			// Todo: Move this parsing to specific components and pass ref to params instead
+			// Iterate over and set parameter:value pairs on target object
+			for (JsonObject::iterator paramIt=params.begin(); paramIt!=params.end(); ++paramIt)
+				{
 
-      if (!target_object->set(param_name, param_value)) {
-        reportError("Invalid parameter set.", buffer);
-        continue; // Todo: Should we return or continue?
-      }
-    }
-  }
+					const char * param_name = paramIt->key;
+					const char * param_value = paramIt->value;
+
+					/* Serial.print("Sending command to "); */
+					/* Serial.print(key); */
+					/* Serial.print(": "); */
+					/* Serial.print(param_name); */
+					/* Serial.print(" : "); */
+					/* Serial.println(param_value); */
+
+					if (!target_object->set(param_name, param_value)) {
+						reportError("Invalid parameter set.", buffer);
+						continue; // Todo: Should we return or continue?
+					}
+				}
+		}
 }
 
-void setup() 
+void setup()
 {
-  delay(1000);
-  
-  // Latch power shutdown line high to keep board from turning off.
-  pinMode(board::PWR_KILL, OUTPUT);
-  digitalWrite(board::PWR_KILL, HIGH);
+	delay(1000);
 
-  // Initialize debugging serial console.
-  Serial.begin(115200);
+	// Latch power shutdown line high to keep board from turning off.
+	pinMode(board::PWR_KILL, OUTPUT);
+	digitalWrite(board::PWR_KILL, HIGH);
 
-  // Start the system in the disconnected state
-  system_state = DISCONNECTED;
-  
-  // Set ADC Precision:
-  analogReadResolution(12);
+	// Initialize debugging serial console.
+	Serial.begin(115200);
+	// Start the system in the disconnected state
+	serial_state = SerialState::STANDBY;
 
-  /*
-  // Set GPS Settings
-  Serial1.begin(9600);
-  Serial1.setTimeout(250);
-  // Set output to RMC only
-  Serial1.println(PMTK_SET_NMEA_OUTPUT_RMCONLY);
-  Serial1.flush();
-  // Set output rate to 5Hz
-  Serial1.println(PMTK_API_SET_FIX_CTL_5HZ);
-  // Set fix rate to 5Hz
-  Serial1.println(PMTK_SET_NMEA_UPDATE_5HZ);
-  Serial1.flush();
-  */
+	// Set ADC Precision:
+	analogReadResolution(12);
 
-  // Initialize and power all peripherals (WiFi & Pump)
-  platypus::peripherals[0] = new platypus::Peripheral(0, true);
-  platypus::peripherals[1] = new platypus::Peripheral(1, true);
+	/*
+	// Set GPS Settings
+	Serial1.begin(9600);
+	Serial1.setTimeout(250);
+	// Set output to RMC only
+	Serial1.println(PMTK_SET_NMEA_OUTPUT_RMCONLY);
+	Serial1.flush();
+	// Set output rate to 5Hz
+	Serial1.println(PMTK_API_SET_FIX_CTL_5HZ);
+	// Set fix rate to 5Hz
+	Serial1.println(PMTK_SET_NMEA_UPDATE_5HZ);
+	Serial1.flush();
+	*/
 
-  // Initialize External sensors
-  platypus::sensors[0] = new platypus::AdafruitGPS(0, 0);
-  platypus::sensors[1] = new platypus::AdafruitGPS(1, 1);
-  platypus::sensors[2] = new platypus::AdafruitGPS(2, 2);
-  platypus::sensors[3] = new platypus::EmptySensor(3, 3);
+	// Initialize EBoard object
+	platypus::eboard = new platypus::EBoard();
 
-  // Initialize Internal sensors
-  platypus::sensors[4] = new platypus::BatterySensor(4);
-  platypus::sensors[5] = new platypus::IMU(5);
-  
-  // Initialize motors
-  platypus::motors[0] = new platypus::Dynamite(0);
-  platypus::motors[1] = new platypus::Dynamite(1);
+	// Initialize and power all peripherals (WiFi & Pump)
+	platypus::peripherals[0] = new platypus::Peripheral(0, true);
+	platypus::peripherals[1] = new platypus::Peripheral(1, true);
 
-  // Make the ADK buffers into null terminated string.
-  debug_buffer[INPUT_BUFFER_SIZE] = '\0';
-  input_buffer[INPUT_BUFFER_SIZE] = '\0';
-  output_buffer[OUTPUT_BUFFER_SIZE] = '\0';
-  
-  // Create secondary tasks for system.
-  Scheduler.startLoop(motorUpdateLoop);
-  Scheduler.startLoop(serialConsoleLoop);
+	// Initialize External sensors
+	platypus::sensors[0] = new platypus::AdafruitGPS(0, 0);
+	platypus::sensors[1] = new platypus::AdafruitGPS(1, 1);
+	platypus::sensors[2] = new platypus::AdafruitGPS(2, 2);
+	platypus::sensors[3] = new platypus::EmptySensor(3, 3);
 
-  // Initialize Platypus library.
-  platypus::init();
-  
-  // Print header indicating that board successfully initialized
-  Serial.println(F("------------------------------"));
-  Serial.println(companyName);
-  Serial.println(url);
-  Serial.println(accessoryName);
-  Serial.println(versionNumber);
-  Serial.println(F("------------------------------"));
-  
-  // Turn LED to startup state.
-  rgb_led.set(255, 0, 255);
-  delay(1000);
+	// Initialize Internal sensors
+	platypus::sensors[4] = new platypus::BatterySensor(4);
+	// platypus::sensors[5] = new platypus::IMU(5);
+
+
+	// Initialize motors
+	platypus::motors[0] = new platypus::Dynamite(0);
+	platypus::motors[1] = new platypus::Dynamite(1);
+
+	// Make the ADK buffers into null terminated string.
+	debug_buffer[INPUT_BUFFER_SIZE] = '\0';
+	input_buffer[INPUT_BUFFER_SIZE] = '\0';
+	output_buffer[OUTPUT_BUFFER_SIZE] = '\0';
+	// Create secondary tasks for system.
+	Scheduler.startLoop(motorUpdateLoop);
+	Scheduler.startLoop(serialLoop);
+	Scheduler.startLoop(ADKLoop);
+
+	// Initialize Platypus library.
+	platypus::init();
+
+	// Print header indicating that board successfully initialized
+
+	Serial.println(F("------------------------------"));
+	Serial.println(companyName);
+	Serial.println(url);
+	Serial.println(accessoryName);
+	Serial.println(versionNumber);
+	Serial.println(F("------------------------------"));
+
+	// Turn LED to startup state.
+	rgb_led.set(255, 0, 255);
+	delay(1000);
 }
 
-void loop() 
+void loop()
 {
-  // Keep track of how many reads we haven't made so far.
-  static unsigned long last_command_time = 0;
+	/* Serial.print("last cmd recvd: "); */
+	/* Serial.println(last_command_time); */
 
-  // Keep track of last time USB connection was detected
-  static unsigned long last_usb_connection_time = 0;
-  
-  // Number of bytes received from USB.
-  uint32_t bytes_read = 0;
-  
-  // Do USB bookkeeping.
-  Usb.Task();
-  
-  // Report system as shutdown if not connected to USB.
-  if (!adk.isReady())
-  {
-    unsigned long current_time = millis();
-    // If not connected to USB, we are 'DISCONNECTED'.
-    if (system_state != DISCONNECTED)
-    {
-      Serial.println("WARNING: USB connection state fault");
-      if (current_time - last_usb_connection_time >= CONNECTION_TIMEOUT_MS){
-        Serial.println("STATE: DISCONNECTED");
-        system_state = DISCONNECTED;
-      }
-    }
-    
-    // Wait for USB connection again.
-    yield();
-    return;
-  } 
-  else 
-  {  
-    // If connected to USB, we are now 'CONNECTED'!
-    if (system_state == DISCONNECTED)
-    {
-      Serial.println("STATE: CONNECTED");
-      system_state = CONNECTED;
-      last_usb_connection_time = millis();
-    }
-  }
-        
-  // Attempt to read command from USB.
-  adk.read(&bytes_read, INPUT_BUFFER_SIZE, (uint8_t*)input_buffer);
-  unsigned long current_command_time = millis();
-  if (bytes_read <= 0) 
-  {
-    // If we haven't received a response in a long time, maybe 
-    // we are 'CONNECTED' but the server is not running.
-    if (current_command_time - last_command_time >= RESPONSE_TIMEOUT_MS)
-    {
-      if (system_state == RUNNING)
-      {
-        Serial.println("STATE: CONNECTED");
-        system_state = CONNECTED; 
-      }
-    }
-    
-    // Wait for more USB data again.
-    yield();
-    return;
-  } 
-  else 
-  {
-    // If we received a command, the server must be 'RUNNING'.
-    if (system_state == CONNECTED) 
-    {
-      Serial.println("STATE: RUNNING");
-      system_state = RUNNING; 
-    }
-    
-    // Update the timestamp of last received command.
-    last_command_time = current_command_time;
-    last_usb_connection_time = current_command_time;
-  }
-  
-  // Properly null-terminate the buffer.
-  input_buffer[bytes_read] = '\0';
-  
-  // Copy incoming message to debug console.
-  //Serial.print("<- ");
-  //Serial.println(input_buffer);
-  
-  // Attempt to parse command
-  handleCommand(input_buffer);
+	//Serial.println(serial_state);
+	unsigned long current_time = millis();
+	if (serial_state == SerialState::ACTIVE) //if youre in active drop to connected
+		{
+			if (millis() - last_command_time >= RESPONSE_TIMEOUT_MS)
+				{
+					serial_state = SerialState::CONNECTED;
+					Serial.println("STATE: CONNECTED");
+					last_command_time = millis();
+				}
+		}
+	else if (serial_state == SerialState::CONNECTED)
+		{
+			/* Serial.println("time diff");	 */
+			/* Serial.println(millis() - last_command_time); */
+			if (millis() - last_command_time >= CONNECT_STANDBY_TIMEOUT)
+				{
+					serial_state = SerialState::STANDBY;
+		Serial.println("STATE: STANDBY");
+				}
+		}
+	yield();
 }
+
+void batteryUpdateLoop()
+{
+	int rawVoltage = analogRead(board::V_BATT);
+	double voltageReading = 0.008879*rawVoltage + 0.09791;
+
+	char output_str[128];
+	snprintf(output_str, 128,
+					 "{"
+					 "\"s4\":{"
+					 "\"type\":\"battery\","
+					 "\"data\":\"%.3f %f %f\""
+					 "}"
+					 "}",
+					 voltageReading,
+					 platypus::motors[0]->velocity(),
+					 platypus::motors[1]->velocity()
+					 );
+	send(output_str);
+	yield();
+}
+
 
 /**
  * Periodically sends motor velocity updates.
  */
 void motorUpdateLoop()
 {
-  // Wait for a fixed time period.
-  delay(100);
-  
-  // Set the LED for current system state.
-  unsigned c = (millis() >> 8) & 1;
-  if (c > 128) c = 255 - c;
- 
-  switch (system_state)
-  {
-  case DISCONNECTED:
-    // Red pulse
-    rgb_led.set(c, 0, 0);
-    break;
-  case CONNECTED:
-    // Yellow pulse
-    rgb_led.set(c, c/4, 0);
-    break;
-  case RUNNING:
-    // Green pulse
-    rgb_led.set(0, c, 0);
-    break;
-  }
-  
-  // Handle the motors appropriately for each system state.
-  switch (system_state)
-  {
-  case DISCONNECTED:
-    // Turn off motors.
-    for (size_t motor_idx = 0; motor_idx < board::NUM_MOTORS; ++motor_idx) 
-    {
-      platypus::Motor* motor = platypus::motors[motor_idx];
-      if (motor->enabled())
-      {
-        Serial.print("Disabling motor "); Serial.println(motor_idx);
-        motor->disable();
-      }
-    }
-    break;
-  case CONNECTED:
-    // Decay all motors exponentially towards zero speed.
-    for (size_t motor_idx = 0; motor_idx < board::NUM_MOTORS; ++motor_idx) 
-    {
-      platypus::Motor* motor = platypus::motors[motor_idx];
-      motor->set("v", "0.0");
-    }
-    // NOTE: WE DO NOT BREAK OUT OF THE SWITCH HERE!
-  case RUNNING:
-    // Rearm motors if necessary.
-    for (size_t motor_idx = 0; motor_idx < board::NUM_MOTORS; ++motor_idx) 
-    {
-      platypus::Motor* motor = platypus::motors[motor_idx];
-      if (!motor->enabled()) 
-      {
-        Serial.print("Arming motor "); Serial.print(motor_idx);
-        motor->arm();
-        Serial.println(F("Motor Armed"));
-      }
-    }
-    break;
-  }
-  
-  // Send status updates while connected to server.
-  if (system_state == RUNNING)
-  {
-    // TODO: move this to another location (e.g. Motor)
-    // Send motor status update over USB
-    snprintf(output_buffer, OUTPUT_BUFFER_SIZE,
-      "{"
-        "\"m0\":{"
-          "\"v\":%f"
-        "},"
-        "\"m1\":{"
-          "\"v\":%f"
-        "}"
-      "}",
-      platypus::motors[0]->velocity(),
-      platypus::motors[1]->velocity()
-    );
-    send(output_buffer);
-  }
+	// Wait for a fixed time period.
+	delay(100);
+
+	// Set the LED for current system state.
+	unsigned c = (millis() >> 8) & 1;
+	if (c > 128) c = 255 - c;
+
+	/* REPLACE WITH SERIAL STATE */
+
+	switch (serial_state)
+		{
+		case SerialState::STANDBY:
+			// Red pulse
+			rgb_led.set(c, 0, 0);
+			break;
+		case SerialState::CONNECTED:
+			// Yellow pulse
+			rgb_led.set(c, c/4, 0);
+			break;
+		case SerialState::ACTIVE:
+			// Green pulse
+			rgb_led.set(0, c, 0);
+			break;
+		}
+
+	// Handle the motors appropriately for each system state.
+	switch (serial_state)
+		{
+		case SerialState::STANDBY:
+			// Turn off motors.
+			for (size_t motor_idx = 0; motor_idx < board::NUM_MOTORS; ++motor_idx)
+				{
+					platypus::Motor* motor = platypus::motors[motor_idx];
+					if (motor->enabled())
+						{
+							Serial.print("Disabling motor "); Serial.println(motor_idx);
+							motor->disable();
+						}
+				}
+			break;
+		case SerialState::CONNECTED:
+			// Decay all motors exponentially towards zero speed.
+			for (size_t motor_idx = 0; motor_idx < board::NUM_MOTORS; ++motor_idx)
+				{
+					platypus::Motor* motor = platypus::motors[motor_idx];
+					motor->set("v", "0.0"); 
+				}
+			// NOTE: WE DO NOT BREAK OUT OF THE SWITCH HERE!
+		case SerialState::ACTIVE:
+			// Rearm motors if necessary.
+			for (size_t motor_idx = 0; motor_idx < board::NUM_MOTORS; ++motor_idx)
+				{
+					platypus::Motor* motor = platypus::motors[motor_idx];
+					if (!motor->enabled())
+						{
+							Serial.print("Arming motor "); Serial.print(motor_idx);
+							motor->arm();
+							Serial.println(F("Motor Armed"));
+						}
+				}
+			break;
+		}
+
+	// Send status updates while connected to server.
+	if (serial_state == SerialState::ACTIVE)
+		{
+			// TODO: move this to another location (e.g. Motor)
+			// Send motor status update over USB
+			snprintf(output_buffer, OUTPUT_BUFFER_SIZE,
+							 "{"
+							 "\"m0\":{"
+							 "\"v\":%f"
+							 "},"
+							 "\"m1\":{"
+							 "\"v\":%f"
+							 "}"
+							 "}",
+							 platypus::motors[0]->velocity(),
+							 platypus::motors[1]->velocity()
+							 );
+			send(output_buffer);
+		}
+	yield();
 }
 
 /**
  * Reads from serial debugging console and attempts to execute commands.
  */
-void serialConsoleLoop()
+
+void serialLoop()
 {
-  // Index to last character in debug buffer.
-  static size_t debug_buffer_idx = 0;
-  
-  // Wait until characters are received.
-  while (!Serial.available()) yield();
+	unsigned long current_command_time = millis();
+	static size_t debug_buffer_idx = 0;
+	// Wait until characters are received.
 
-  // Put the new character into the buffer, ignore \n and \r
-  char c = Serial.read();
-  if (c != '\n' && c != '\r'){
-    debug_buffer[debug_buffer_idx++] = c;
-  }
-  
-  // If it is the end of a line, or we are out of space, parse the buffer.
-  if (debug_buffer_idx >= INPUT_BUFFER_SIZE || c == '\n' || c == '\r') 
-  {
-    // Properly null-terminate the buffer.
-    debug_buffer[debug_buffer_idx] = '\0';
-    debug_buffer_idx = 0;
-
-    //Serial.println(debug_buffer);
-    if (strcmp(debug_buffer, "DOc") == 0){
-      platypus::sensors[1]->calibrate(1);
-    } else if (strcmp(debug_buffer, "DOc0") == 0){
-      platypus::sensors[1]->calibrate(0);
-    } else if (strcmp(debug_buffer, "PHcm") == 0){
-      platypus::sensors[2]->calibrate(0.0);
-    } else if (strcmp(debug_buffer, "PHcl") == 0){
-      platypus::sensors[2]->calibrate(-1);
-    } else if (strcmp(debug_buffer, "PHch") == 0){
-      platypus::sensors[2]->calibrate(1);
-    }
-    // Attempt to parse command.
-    handleCommand(debug_buffer); 
-  }
+	if (Serial.available())
+		{
+			// Put the new character into the buffer, ignore \n and \r
+			char c = Serial.read();
+			if (c != '\n' && c != '\r'){
+				debug_buffer[debug_buffer_idx++] = c;
+			}
+			// If it is the end of a line, or we are out of space, parse the buffer.
+			if (debug_buffer_idx >= INPUT_BUFFER_SIZE || c == '\n' || c == '\r')
+				{
+					// Properly null-terminate the buffer.
+					debug_buffer[debug_buffer_idx] = '\0';
+					debug_buffer_idx = 0;
+		
+					last_command_time = current_command_time;
+					handleCommand(debug_buffer);
+				}
+		}
+	yield();
 }
+void ADKLoop()
+{
+	uint32_t bytes_read;
+	Usb.Task();
+	if (adk.isReady())
+		{
+			//read from adk usb
+			if (serial_state != SerialState::ACTIVE)
+	{
+		serial_state = SerialState::ACTIVE;
+		Serial.println("STATE: ACTIVE");
+	}
+			unsigned long current_command_time = millis();
+			adk.read(&bytes_read, INPUT_BUFFER_SIZE, (uint8_t*)input_buffer);
 
+			if (bytes_read <= 0)
+				{
+					yield();
+					return;
+				}
+			else
+				{
+					last_command_time = current_command_time;
+					input_buffer[bytes_read] = '\0';
+					handleCommand(input_buffer);
+				}
+		}
+	yield();
+}

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -16,11 +16,10 @@
 //Typedefs
 typedef platypus::SerialState SerialState;
 
-/* 
-	 MAJOR BUG
-	 restarting adk connection (plug out then in) causes one motor to go full speed
- */
-
+/*
+  MAJOR BUG
+  restarting adk connection (plug out then in) causes one motor to go full speed
+*/
 
 
 // ADK USB Host configuration
@@ -38,8 +37,8 @@ char boardVersion[] = "4.2.0";
 
 
 #define PMTK_SET_NMEA_OUTPUT_RMCONLY "$PMTK314,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*29"
-#define PMTK_SET_NMEA_UPDATE_5HZ	"$PMTK220,200*2C"
-#define PMTK_API_SET_FIX_CTL_5HZ	"$PMTK300,200,0,0,0,0*2F"
+#define PMTK_SET_NMEA_UPDATE_5HZ  "$PMTK220,200*2C"
+#define PMTK_API_SET_FIX_CTL_5HZ  "$PMTK300,200,0,0,0,0*2F"
 
 
 // ADK USB Host
@@ -56,9 +55,6 @@ char output_buffer[OUTPUT_BUFFER_SIZE+3];
 
 static unsigned long last_command_time = 0;
 static unsigned long time_at_connected = 0;
-
-// System state enumeration
-SerialState serial_state = SerialState::STANDBY;
 
 // Time betweeen commands before we consider the Android
 // server to be unresponsive.
@@ -79,18 +75,18 @@ platypus::Led rgb_led;
  */
 void send(char *str)
 {
-	// Add newline termination
-	// TODO: Make sure we don't buffer overflow
-	size_t len = strlen(str);
-	str[len++] = '\r';
-	str[len++] = '\n';
-	str[len] = '\0';
+  // Add newline termination
+  // TODO: Make sure we don't buffer overflow
+  size_t len = strlen(str);
+  str[len++] = '\r';
+  str[len++] = '\n';
+  str[len] = '\0';
 
-	// Write string to USB.
-	if (adk.isReady()) adk.write(len, (uint8_t*)str);
-	// Copy string to debugging console.
-	Serial.print("-> ");
-	Serial.print(str);
+  // Write string to USB.
+  if (adk.isReady()) adk.write(len, (uint8_t*)str);
+  // Copy string to debugging console.
+  Serial.print("-> ");
+  Serial.print(str);
 }
 
 /**
@@ -99,14 +95,14 @@ void send(char *str)
  */
 void reportError(const char *error_message, const char *buffer)
 {
-	// Construct a JSON error message.
-	snprintf(output_buffer, OUTPUT_BUFFER_SIZE,
-					 "{"
-					 "\"error\": \"%s\","
-					 "\"args\": \"%s\""
-					 "}",
-					 error_message, buffer);
-	send(output_buffer);
+  // Construct a JSON error message.
+  snprintf(output_buffer, OUTPUT_BUFFER_SIZE,
+           "{"
+           "\"error\": \"%s\","
+           "\"args\": \"%s\""
+           "}",
+           error_message, buffer);
+  send(output_buffer);
 }
 
 /**
@@ -115,223 +111,232 @@ void reportError(const char *error_message, const char *buffer)
  */
 void handleCommand(char *buffer)
 {
-	// Allocate buffer for JSON parsing
-	StaticJsonBuffer<200> jsonBuffer;
+  // Allocate buffer for JSON parsing
+  if (strcmp(buffer,"arm")==0)
+  {
+    platypus::eboard->set("cmd","arm");
+    return;
+  }
+	
+  StaticJsonBuffer<200> jsonBuffer;
 
-	// Attempt to parse JSON in buffer
-	JsonObject& command = jsonBuffer.parseObject(buffer);
+  // Attempt to parse JSON in buffer
+  JsonObject& command = jsonBuffer.parseObject(buffer);
 
-	// Check for parsing error
-	if (!command.success())
-		{
-			// Parsing Failure
-			reportError("Failed to parse JSON command.", buffer);
-			return;
-		}
+  // Check for parsing error
+  if (!command.success())
+  {
+    // Parsing Failure
+    reportError("Failed to parse JSON command.", buffer);
+    return;
+  }
 
-	for (JsonObject::iterator it=command.begin(); it!=command.end(); ++it)
-		{
-			const char * key = it->key;
+  for (JsonObject::iterator it=command.begin(); it!=command.end(); ++it)
+  {
+    const char * key = it->key;
 
-			platypus::Configurable * target_object;
-			size_t object_index;
+    platypus::Configurable * target_object;
+    size_t object_index;
 
-			// Determine target object
-			switch (key[0]){
-			case 'm': // Motor command
-				object_index = key[1] - '0';
+		/* if (key[0] != 'e') */
+		/* { */
+		/* 	last_command_time = millis(); */
+		/* } */
 
-				if (object_index >= board::NUM_MOTORS){
-					reportError("Invalid motor index.", buffer);
-					return;
-				}
+    // Determine target object
+    switch (key[0]){
+    case 'm': // Motor command
+      object_index = key[1] - '0';
 
-				target_object = platypus::motors[object_index];
-				break;
+      if (object_index >= board::NUM_MOTORS){
+        reportError("Invalid motor index.", buffer);
+        return;
+      }
 
-			case 's': // Sensor command
-				object_index = key[1] - '0';
+      target_object = platypus::motors[object_index];
+      break;
 
-				if (object_index >= board::NUM_SENSORS){
-					reportError("Invalid sensor index.", buffer);
-					return;
-				}
-				target_object = platypus::sensors[object_index];
-				break;
+    case 's': // Sensor command
+      object_index = key[1] - '0';
 
-			case 'e': //eboard command
-				target_object = platypus::eboard;
-				serial_state = SerialState::CONNECTED;
-				Serial.println("STATE: CONNECTED");
-				break;
+      if (object_index >= board::NUM_SENSORS){
+        reportError("Invalid sensor index.", buffer);
+        return;
+      }
+      target_object = platypus::sensors[object_index];
+      break;
 
-			default: // Unrecognized target
-				reportError("Unknown command target.", buffer);
-				return;
-			}
+    case 'e': //eboard command
+      target_object = platypus::eboard;
+      break;
 
-			// Extract JsonObject with param:value pairs
-			JsonObject& params = it->value;
-			// Todo: Move this parsing to specific components and pass ref to params instead
-			// Iterate over and set parameter:value pairs on target object
-			for (JsonObject::iterator paramIt=params.begin(); paramIt!=params.end(); ++paramIt)
-				{
+    default: // Unrecognized target
+      reportError("Unknown command target.", buffer);
+      return;
+    }
 
-					const char * param_name = paramIt->key;
-					const char * param_value = paramIt->value;
+    // Extract JsonObject with param:value pairs
+    JsonObject& params = it->value;
+    // Todo: Move this parsing to specific components and pass ref to params instead
+    // Iterate over and set parameter:value pairs on target object
+    for (JsonObject::iterator paramIt=params.begin(); paramIt!=params.end(); ++paramIt)
+    {
 
-					Serial.print("Sending command to ");
-					Serial.print(key);
-					Serial.print(": ");
-					Serial.print(param_name);
-					Serial.print(" : ");
-					Serial.println(param_value);
+      const char * param_name = paramIt->key;
+      const char * param_value = paramIt->value;
 
-					if (!target_object->set(param_name, param_value)) {
-						reportError("Invalid parameter set.", buffer);
-						continue; // Todo: Should we return or continue?
-					}
-				}
-		}
+      /* Serial.print("Sending command to "); */
+      /* Serial.print(key); */
+      /* Serial.print(": "); */
+      /* Serial.print(param_name); */
+      /* Serial.print(" : "); */
+      /* Serial.println(param_value); */
+
+      if (!target_object->set(param_name, param_value)) {
+        reportError("Invalid parameter set.", buffer);
+        continue; // Todo: Should we return or continue?
+      }
+    }
+  }
 }
 
 void setup()
 {
-	delay(1000);
+  delay(1000);
 
-	// Latch power shutdown line high to keep board from turning off.
-	pinMode(board::PWR_KILL, OUTPUT);
-	digitalWrite(board::PWR_KILL, HIGH);
+  // Latch power shutdown line high to keep board from turning off.
+  pinMode(board::PWR_KILL, OUTPUT);
+  digitalWrite(board::PWR_KILL, HIGH);
 
-	// Initialize debugging serial console.
-	Serial.begin(115200);
-	// Start the system in the disconnected state
-	serial_state = SerialState::STANDBY;
-	Serial.println("STATE: STANDBY");
+  // Initialize debugging serial console.
+  Serial.begin(115200);
+  // Start the system in the disconnected state
 
-	// Set ADC Precision:
-	analogReadResolution(12);
+  // Set ADC Precision:
+  analogReadResolution(12);
 
-	/*
-	// Set GPS Settings
-	Serial1.begin(9600);
-	Serial1.setTimeout(250);
-	// Set output to RMC only
-	Serial1.println(PMTK_SET_NMEA_OUTPUT_RMCONLY);
-	Serial1.flush();
-	// Set output rate to 5Hz
-	Serial1.println(PMTK_API_SET_FIX_CTL_5HZ);
-	// Set fix rate to 5Hz
-	Serial1.println(PMTK_SET_NMEA_UPDATE_5HZ);
-	Serial1.flush();
-	*/
+  /*
+  // Set GPS Settings
+  Serial1.begin(9600);
+  Serial1.setTimeout(250);
+  // Set output to RMC only
+  Serial1.println(PMTK_SET_NMEA_OUTPUT_RMCONLY);
+  Serial1.flush();
+  // Set output rate to 5Hz
+  Serial1.println(PMTK_API_SET_FIX_CTL_5HZ);
+  // Set fix rate to 5Hz
+  Serial1.println(PMTK_SET_NMEA_UPDATE_5HZ);
+  Serial1.flush();
+  */
 
-	// Initialize EBoard object
-	platypus::eboard = new platypus::EBoard();
+  // Initialize EBoard object
+  platypus::eboard = new platypus::EBoard();
+  platypus::eboard->setState(SerialState::STANDBY);
 
-	// Initialize and power all peripherals (WiFi & Pump)
-	platypus::peripherals[0] = new platypus::Peripheral(0, true);
-	platypus::peripherals[1] = new platypus::Peripheral(1, true);
+  // Initialize and power all peripherals (WiFi & Pump)
+  platypus::peripherals[0] = new platypus::Peripheral(0, true);
+  platypus::peripherals[1] = new platypus::Peripheral(1, true);
 
-	// Initialize External sensors
-	platypus::sensors[0] = new platypus::AdafruitGPS(0, 0);
-	platypus::sensors[1] = new platypus::AdafruitGPS(1, 1);
-	platypus::sensors[2] = new platypus::AdafruitGPS(2, 2);
-	platypus::sensors[3] = new platypus::EmptySensor(3, 3);
+  // Initialize External sensors
+  platypus::sensors[0] = new platypus::AdafruitGPS(0, 0);
+  platypus::sensors[1] = new platypus::AdafruitGPS(1, 1);
+  platypus::sensors[2] = new platypus::AdafruitGPS(2, 2);
+  platypus::sensors[3] = new platypus::EmptySensor(3, 3);
 
-	// Initialize Internal sensors
-	platypus::sensors[4] = new platypus::BatterySensor(4);
-	// platypus::sensors[5] = new platypus::IMU(5);
+  // Initialize Internal sensors
+  platypus::sensors[4] = new platypus::BatterySensor(4);
+  // platypus::sensors[5] = new platypus::IMU(5);
 
 
-	// Initialize motors
-	platypus::motors[0] = new platypus::Dynamite(0);
-	platypus::motors[1] = new platypus::Dynamite(1);
+  // Initialize motors
+  platypus::motors[0] = new platypus::Dynamite(0);
+  platypus::motors[1] = new platypus::Dynamite(1);
 
-	// Make the ADK buffers into null terminated string.
-	debug_buffer[INPUT_BUFFER_SIZE] = '\0';
-	input_buffer[INPUT_BUFFER_SIZE] = '\0';
-	output_buffer[OUTPUT_BUFFER_SIZE] = '\0';
-	// Create secondary tasks for system.
-	Scheduler.startLoop(motorUpdateLoop);
-	Scheduler.startLoop(serialLoop);
-	Scheduler.startLoop(ADKLoop);
+  // Make the ADK buffers into null terminated string.
+  debug_buffer[INPUT_BUFFER_SIZE] = '\0';
+  input_buffer[INPUT_BUFFER_SIZE] = '\0';
+  output_buffer[OUTPUT_BUFFER_SIZE] = '\0';
+  // Create secondary tasks for system.
+  Scheduler.startLoop(motorUpdateLoop);
+  Scheduler.startLoop(serialLoop);
+  Scheduler.startLoop(ADKLoop);
 
-	// Initialize Platypus library.
-	platypus::init();
+  // Initialize Platypus library.
+  platypus::init();
 
-	// Print header indicating that board successfully initialized
+  // Print header indicating that board successfully initialized
 
-	Serial.println(F("------------------------------"));
-	Serial.println(companyName);
-	Serial.println(url);
-	Serial.println(accessoryName);
-	Serial.println(versionNumber);
-	Serial.println(F("------------------------------"));
+  Serial.println(F("------------------------------"));
+  Serial.println(companyName);
+  Serial.println(url);
+  Serial.println(accessoryName);
+  Serial.println(versionNumber);
+  Serial.println(F("------------------------------"));
 
-	// Turn LED to startup state.
-	rgb_led.set(255, 0, 255);
-	delay(1000);
+  // Turn LED to startup state.
+  rgb_led.set(255, 0, 255);
+  delay(1000);
 }
 
 void loop()
 {
-	/* if (serial_state == SerialState::ACTIVE) */
-	/*		Serial.println("active"); */
-	/* if (serial_state == SerialState::CONNECTED) */
-	/*		Serial.println("connected"); */
-	/* if (serial_state == SerialState::STANDBY) */
-	/*		Serial.println("standby"); */
-		
-	unsigned long current_time = millis();
-	if (serial_state == SerialState::ACTIVE) //if youre in active drop to connected
-		{
-			if (millis() - last_command_time >= RESPONSE_TIMEOUT_MS)
-				{
-					serial_state = SerialState::CONNECTED;
-					Serial.println("STATE: CONNECTED");
-					last_command_time = millis();
-				}
-		}
-	else if (serial_state == SerialState::CONNECTED)
-		{
-			/* Serial.println("time diff");	 */
-			/* Serial.println(millis() - last_command_time); */
-			if (millis() - last_command_time >= CONNECT_STANDBY_TIMEOUT)
-				{
-					serial_state = SerialState::STANDBY;
-					Serial.println("STATE: STANDBY");
-				}
-		}
-	/* if (serial_state == SerialState::STANDBY) */
-	/*		{ */
-	/*			if (millis() - last_command_time < CONNECT_STANDBY_TIMEOUT) */
-	/*				{ */
-	/*					serial_state = SerialState::CONNECTED; */
-	/*				} */
-	/*		} */
-	yield();
+
+  /* if (serial_state == SerialState::ACTIVE) */
+  /*    Serial.println("active"); */
+  /* if (serial_state == SerialState::CONNECTED) */
+  /*    Serial.println("connected"); */
+  /* if (serial_state == SerialState::STANDBY) */
+  /*    Serial.println("standby"); */
+  /* if (platypus::eboard->serial_state == SerialState::ACTIVE) */
+  /*    Serial.println("active"); */
+  /* if (platypus::eboard->serial_state == SerialState::CONNECTED) */
+  /*    Serial.println("connected"); */
+  /* if (platypus::eboard->serial_state == SerialState::STANDBY) */
+  /*    Serial.println("standby"); */
+
+
+  unsigned long current_time = millis();
+  if (platypus::eboard->getState() == SerialState::ACTIVE) //if youre in active drop to connected
+  {
+    if (millis() - last_command_time >= RESPONSE_TIMEOUT_MS)
+    {
+      platypus::eboard->setState(SerialState::CONNECTED);
+      Serial.println("STATE: CONNECTED");
+      last_command_time = millis();
+    }
+  }
+  else if (platypus::eboard->getState() == SerialState::CONNECTED)
+  {
+    /* Serial.println("time diff");  */
+    /* Serial.println(millis() - last_command_time); */
+    if (millis() - last_command_time >= CONNECT_STANDBY_TIMEOUT)
+    {
+      platypus::eboard->setState(SerialState::STANDBY);
+      Serial.println("STATE: STANDBY");
+    }
+  }
+  yield();
 }
 
 void batteryUpdateLoop()
 {
-	int rawVoltage = analogRead(board::V_BATT);
-	double voltageReading = 0.008879*rawVoltage + 0.09791;
+  int rawVoltage = analogRead(board::V_BATT);
+  double voltageReading = 0.008879*rawVoltage + 0.09791;
 
-	char output_str[128];
-	snprintf(output_str, 128,
-					 "{"
-					 "\"s4\":{"
-					 "\"type\":\"battery\","
-					 "\"data\":\"%.3f %f %f\""
-					 "}"
-					 "}",
-					 voltageReading,
-					 platypus::motors[0]->velocity(),
-					 platypus::motors[1]->velocity()
-					 );
-	send(output_str);
-	yield();
+  char output_str[128];
+  snprintf(output_str, 128,
+           "{"
+           "\"s4\":{"
+           "\"type\":\"battery\","
+           "\"data\":\"%.3f %f %f\""
+           "}"
+           "}",
+           voltageReading,
+           platypus::motors[0]->velocity(),
+           platypus::motors[1]->velocity()
+    );
+  send(output_str);
+  yield();
 }
 
 
@@ -340,89 +345,91 @@ void batteryUpdateLoop()
  */
 void motorUpdateLoop()
 {
-	// Wait for a fixed time period.
-	delay(100);
+  // Wait for a fixed time period.
+  delay(100);
 
-	// Set the LED for current system state.
-	unsigned c = (millis() >> 8) & 1;
-	if (c > 128) c = 255 - c;
+  // Set the LED for current system state.
+  unsigned c = (millis() >> 8) & 1;
+  if (c > 128) c = 255 - c;
 
-	/* REPLACE WITH SERIAL STATE */
+  /* REPLACE WITH SERIAL STATE */
 
-	switch (serial_state)
-		{
-		case SerialState::STANDBY:
-			// Red pulse
-			rgb_led.set(c, 0, 0);
-			break;
-		case SerialState::CONNECTED:
-			// Yellow pulse
-			rgb_led.set(c, c/4, 0);
-			break;
-		case SerialState::ACTIVE:
-			// Green pulse
-			rgb_led.set(0, c, 0);
-			break;
-		}
+  switch (platypus::eboard->getState())
+  {
+  case SerialState::STANDBY:
+    // Red pulse
+    rgb_led.set(c, 0, 0);
+    break;
+  case SerialState::CONNECTED:
+    // Yellow pulse
+    rgb_led.set(c, c/4, 0);
+    break;
+  case SerialState::ACTIVE:
+    // Green pulse
+    rgb_led.set(0, c, 0);
+    break;
+  }
 
-	// Handle the motors appropriately for each system state.
-	switch (serial_state)
-		{
-		case SerialState::STANDBY:
-			// Turn off motors.
-			for (size_t motor_idx = 0; motor_idx < board::NUM_MOTORS; ++motor_idx)
-				{
-					platypus::Motor* motor = platypus::motors[motor_idx];
-					if (motor->enabled())
-						{
-							Serial.print("Disabling motor "); Serial.println(motor_idx);
-							motor->disable();
-						}
-				}
-			break;
-		case SerialState::CONNECTED:
-			// Decay all motors exponentially towards zero speed.
-			for (size_t motor_idx = 0; motor_idx < board::NUM_MOTORS; ++motor_idx)
-				{
-					platypus::Motor* motor = platypus::motors[motor_idx];
-					motor->set("v", "0.0");
-				}
-			// NOTE: WE DO NOT BREAK OUT OF THE SWITCH HERE!
-		case SerialState::ACTIVE:
-			// Rearm motors if necessary.
-			for (size_t motor_idx = 0; motor_idx < board::NUM_MOTORS; ++motor_idx)
-				{
-					platypus::Motor* motor = platypus::motors[motor_idx];
-					if (!motor->enabled())
-						{
-							Serial.print("Arming motor "); Serial.print(motor_idx);
-							motor->arm();
-							Serial.println(F("Motor Armed"));
-						}
-				}
-			break;
-		}
+  // Handle the motors appropriately for each system state.
+  switch (platypus::eboard->getState())
+  {
+  case SerialState::STANDBY:
+    // Turn off motors.
+    for (size_t motor_idx = 0; motor_idx < board::NUM_MOTORS; ++motor_idx)
+    {
+      platypus::Motor* motor = platypus::motors[motor_idx];
+      if (motor->enabled())
+      {
+        Serial.print("Disabling motor "); Serial.println(motor_idx);
+        motor->disable();
+      }
+    }
+    break;
+  case SerialState::CONNECTED:
+    // Decay all motors exponentially towards zero speed.
+    for (size_t motor_idx = 0; motor_idx < board::NUM_MOTORS; ++motor_idx)
+    {
+      platypus::Motor* motor = platypus::motors[motor_idx];
+      motor->set("v", "0.0");
+    }
+		break;
+    // NOTE: WE DO NOT BREAK OUT OF THE SWITCH HERE!
+		
+  case SerialState::ACTIVE:
+    // Rearm motors if necessary.
+    for (size_t motor_idx = 0; motor_idx < board::NUM_MOTORS; ++motor_idx)
+    {
+      platypus::Motor* motor = platypus::motors[motor_idx];
+      if (!motor->enabled())
+      {
+        Serial.print("Arming motor "); Serial.print(motor_idx);
+        motor->arm();
+        Serial.println(F("Motor Armed"));
+      }
+    }
+    break;
+  }
 
-	// Send status updates while connected to server.
-	if (serial_state == SerialState::ACTIVE)
-		{
-			// TODO: move this to another location (e.g. Motor)
-			// Send motor status update over USB
-			snprintf(output_buffer, OUTPUT_BUFFER_SIZE,
-							 "{"
-							 "\"m0\":{"
-							 "\"v\":%f"
-							 "},"
-							 "\"m1\":{"
-							 "\"v\":%f"
-							 "}"
-							 "}",
-							 platypus::motors[0]->velocity(),
-							 platypus::motors[1]->velocity()
-							 );
-			send(output_buffer);
-		}
-	yield();
+  // Send status updates while connected to server.
+  if (platypus::eboard->getState() == SerialState::ACTIVE)
+  {
+    // TODO: move this to another location (e.g. Motor)
+    // Send motor status update over USB
+    snprintf(output_buffer, OUTPUT_BUFFER_SIZE,
+             "{"
+             "\"m0\":{"
+             "\"v\":%f"
+             "},"
+             "\"m1\":{"
+             "\"v\":%f"
+             "}"
+             "}",
+             platypus::motors[0]->velocity(),
+             platypus::motors[1]->velocity()
+      );
+    send(output_buffer);
+  }
+  yield();
 }
 
 /**
@@ -431,65 +438,61 @@ void motorUpdateLoop()
 
 void serialLoop()
 {
-	unsigned long current_command_time = millis();
-	static size_t debug_buffer_idx = 0;
-	// Wait until characters are received.
+  static size_t debug_buffer_idx = 0;
+  // Wait until characters are received.
 
-	if (Serial.available())
-		{
-			// Put the new character into the buffer, ignore \n and \r
-			char c = Serial.read();
-			if (c != '\n' && c != '\r'){
-				debug_buffer[debug_buffer_idx++] = c;
-			}
-			// If it is the end of a line, or we are out of space, parse the buffer.
-			if (debug_buffer_idx >= INPUT_BUFFER_SIZE || c == '\n' || c == '\r')
-				{
-					// Properly null-terminate the buffer.
-					debug_buffer[debug_buffer_idx] = '\0';
-					debug_buffer_idx = 0;
-					Serial.println(debug_buffer);
+  if (Serial.available())
+  {
+    // Put the new character into the buffer, ignore \n and \r
+    char c = Serial.read();
+    if (c != '\n' && c != '\r'){
+      debug_buffer[debug_buffer_idx++] = c;
+    }
+    // If it is the end of a line, or we are out of space, parse the buffer.
+    if (debug_buffer_idx >= INPUT_BUFFER_SIZE || c == '\n' || c == '\r')
+    {
+      // Properly null-terminate the buffer.
+      debug_buffer[debug_buffer_idx] = '\0';
+      debug_buffer_idx = 0;
+      Serial.println(debug_buffer);
 
-					//last_command_time = current_command_time;
-					last_command_time = millis();
-					handleCommand(debug_buffer);
-				}
-		}
-	yield();
+      last_command_time = millis();
+      handleCommand(debug_buffer);
+    }
+  }
+  yield();
 }
 void ADKLoop()
 {
-	uint32_t bytes_read;
-	Usb.Task();
-	if (adk.isReady())
-		{
-			//read from adk usb
-			if (serial_state != SerialState::ACTIVE)
-				{
-					serial_state = SerialState::ACTIVE;
-					Serial.println("STATE: ACTIVE");
-				}
-			unsigned long current_command_time = millis();
-			adk.read(&bytes_read, INPUT_BUFFER_SIZE, (uint8_t*)input_buffer);
-
-			if (bytes_read <= 0)
-				{
-					yield();
-					return;
-				}
-			else
-				{
-					last_command_time = current_command_time;
-					input_buffer[bytes_read] = '\0';
-					handleCommand(input_buffer);
-				}
-		}
-	else
-		{
-			/* if (serial_state != SerialState::STANDBY) */
-			/*		{ */
-			/*			serial_state = SerialState::STANDBY; */
-			/*		} */
-		}
-	yield();
+  uint32_t bytes_read;
+  Usb.Task();
+  if (adk.isReady())
+  {
+    //read from adk usb
+    if (platypus::eboard->getState() != SerialState::ACTIVE)
+    {
+      platypus::eboard->setState(SerialState::ACTIVE);
+      Serial.println("STATE: ACTIVE");
+    }
+    adk.read(&bytes_read, INPUT_BUFFER_SIZE, (uint8_t*)input_buffer);
+    if (bytes_read <= 0)
+    {
+      yield();
+      return;
+    }
+    else
+    {
+      last_command_time = millis();
+      input_buffer[bytes_read] = '\0';
+      handleCommand(input_buffer);
+    }
+  }
+  else
+  {
+    /* if (serial_state != SerialState::STANDBY) */
+    /*    { */
+    /*      serial_state = SerialState::STANDBY; */
+    /*    } */
+  }
+  yield();
 }

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -51,10 +51,10 @@ char output_buffer[OUTPUT_BUFFER_SIZE+3];
 static unsigned long last_command_time = 0;
 static unsigned long time_at_connected = 0;
 
-// Time betweeen commands before we consider the Android
-// server to be unresponsive.
-const size_t RESPONSE_TIMEOUT_MS = 500;
-const size_t CONNECT_STANDBY_TIMEOUT = 1000;
+// Time betweeen commands before we consider the Android/Raspberry PI
+// server to be unresponsive - keep this fairly loose until heartbeat implemented
+const size_t RESPONSE_TIMEOUT_MS = 3000;
+const size_t CONNECT_STANDBY_TIMEOUT = 5000;
 
 // Define the systems on this board
 // TODO: move this board.h?
@@ -203,8 +203,7 @@ void setup()
   analogReadResolution(12);
 
   
-  // Set GPS Settings
-  
+  // Set GPS Settings - This should go in Adafruit GPS sensor init
   Serial1.begin(9600);
   Serial1.setTimeout(250);
   // Set output to RMC only
@@ -230,7 +229,7 @@ void setup()
   platypus::sensors[0] = new platypus::AdafruitGPS(0, 0);
   platypus::sensors[1] = new platypus::AdafruitGPS(1, 1);
   platypus::sensors[2] = new platypus::AdafruitGPS(2, 2);
-  platypus::sensors[3] = new platypus::EmptySensor(3, 3);
+  platypus::sensors[3] = new platypus::EmptySensor(3, 3); // No serial on sensor 3!!!
 
   // Initialize Internal sensors
   platypus::sensors[4] = new platypus::BatterySensor(4);
@@ -254,7 +253,7 @@ void setup()
   platypus::init();
 
   // Print header indicating that board successfully initialized
-  /* Disable info print for now
+  /* Make this info requestable from eboard object
   Serial.println(F("------------------------------"));
   Serial.println(companyName);
   Serial.println(url);
@@ -262,6 +261,7 @@ void setup()
   Serial.println(versionNumber);
   Serial.println(F("------------------------------"));
   */
+
   // Turn LED to startup state.
   rgb_led.set(255, 0, 255);
   delay(1000);
@@ -273,62 +273,24 @@ void loop()
     If the board is in an active state and hasnt recieved a command
     in a while drop it to connected
   */
-	if (millis() - last_command_time >= RESPONSE_TIMEOUT_MS)
-		{
-			/*You were active, didnt send anything for R.TO now youre being kicked down to connected */
-			if (platypus::eboard->getState() == SerialState::ACTIVE)
-				{
-					platypus::eboard->setState(SerialState::CONNECTED);
-					//Serial.println("STATE: CONNECTED");
-					yield();
-					return;
-				}
-		}
-	
-	if (millis() - last_command_time >= CONNECT_STANDBY_TIMEOUT)
-	{
-		/*You were in connected without recieving a command for a while  */
-		if (platypus::eboard->getState() == SerialState::CONNECTED)
-		{
-			platypus::eboard->setState(SerialState::STANDBY);
-			//Serial.println("STATE: STANDBY");
-		}
-		yield();
-		return;
-	}	
-	/* You were in standby but got a command! bumping you up to connected */
-	else
-	{
-		if (platypus::eboard->getState() == SerialState::STANDBY)
-		{
-			platypus::eboard->setState(SerialState::CONNECTED);
-			//Serial.println("STATE: CONNECTED1");
-		}
-	}
+
+  if (platypus::eboard->getState() == SerialState::ACTIVE){
+    if (millis() - last_command_time >= RESPONSE_TIMEOUT_MS){
+      platypus::eboard->setState(SerialState::CONNECTED);
+      //Serial.println("STATE: CONNECTED");
+    }
+  } else if (platypus::eboard->getState() == SerialState::CONNECTED){
+    if (millis() - last_command_time >= CONNECT_STANDBY_TIMEOUT){
+      platypus::eboard->setState(SerialState::STANDBY);
+      //Serial.println("STATE: STANDBY");
+    }
+  } else if (millis() - last_command_time < CONNECT_STANDBY_TIMEOUT){
+    platypus::eboard->setState(SerialState::CONNECTED);
+    //Serial.println("STATE: CONNECTED");
+  }
+
 	yield();
 }
-
-void batteryUpdateLoop()
-{
-  int rawVoltage = analogRead(board::V_BATT);
-  double voltageReading = 0.008879*rawVoltage + 0.09791;
-
-  char output_str[128];
-  snprintf(output_str, 128,
-           "{"
-           "\"s4\":{"
-           "\"type\":\"battery\","
-           "\"data\":\"%.3f %f %f\""
-           "}"
-           "}",
-           voltageReading,
-           platypus::motors[0]->velocity(),
-           platypus::motors[1]->velocity()
-           );
-  send(output_str);
-  yield();
-}
-
 
 /**
  * Periodically sends motor velocity updates.
@@ -365,14 +327,14 @@ void motorUpdateLoop()
     case SerialState::STANDBY:
       // Turn off motors.
       for (size_t motor_idx = 0; motor_idx < board::NUM_MOTORS; ++motor_idx)
+      {
+        platypus::Motor* motor = platypus::motors[motor_idx];
+        if (motor->enabled())
         {
-          platypus::Motor* motor = platypus::motors[motor_idx];
-          if (motor->enabled())
-          {
-            //Serial.print("Disabling motor "); Serial.println(motor_idx);
-            motor->disable();
-          }
+          //Serial.print("Disabling motor "); Serial.println(motor_idx);
+          motor->disable();
         }
+      }
       break;
     case SerialState::CONNECTED:
       // Decay all motors exponentially towards zero speed.
@@ -382,9 +344,6 @@ void motorUpdateLoop()
         motor->set("v", "0.0");
       }
       break;
-      // NOTE: WE DO NOT BREAK OUT OF THE SWITCH HERE!
-      // NOTE: WE DO NOW
-
     case SerialState::ACTIVE:
       // Rearm motors if necessary.
       for (size_t motor_idx = 0; motor_idx < board::NUM_MOTORS; ++motor_idx)


### PR DESCRIPTION
This branch allows for all commands to come from both ADK devices as well as Serial. Instead of heavily relying on the value of adk.isReady() this branch checks for only command timeouts. 

A configurable object EBoard was added which allows direct interaction with eboard specific commands such as arming and disarming the eboard (new feature) as well as getting the eboards information (although this is not fully implemented). Separating the adk commands and the serial commands will make deprecating adk easy in the future. The board's states were also slightly revised into 

1. Standby: The board is on and has not received any serial commands and adk.isready() returned false, the eboard was in a Connected state but dropped after a timeout 
2. Connected: Either adk.isReady() returned true, the boat is recieving seril commands but none that arm it, or the boat was armed at some point then disarmed 
3. Active: adk.isReady() is true or an eboard arming command was set

- If the EBoard is active but does not receive a command for CONNECTION_TIMEOUT_MS milliseconds it will drop to the connected state. 
- If the EBoard is in the connected state and does not receive any commands for CONNECT_STANDBY_TIMEOUT it will drop to the standby state. 
- The logic around these can be changed based on further discussion. 

I have tested teleop over both serial and arduino and both work, I have not found any issues yet. 

I apologize for the massive diff in the files, I switched over from spaces to tabs and had auto indentation on. Also my emacs kept switching back and forth...